### PR TITLE
Add support for testing file downloads

### DIFF
--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -285,6 +285,9 @@ ShinyDriver <- R6Class(
       sd_uploadFile(self, private, ..., wait_ = wait_, values_ = values_,
                      timeout_ = timeout_),
 
+    snapshotDownload = function(id, filename = NULL)
+      sd_snapshotDownload(self, private, id, filename),
+
     snapshot = function(items = NULL,
                         filename = NULL,
                         screenshot = NULL)

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -65,6 +65,25 @@ sd_snapshotCompare <- function(self, private, autoremove) {
   snapshotCompare(private$snapshotDir, self$getAppDir(), autoremove)
 }
 
+sd_snapshotDownload <- function(self, private, id, filename) {
+
+  current_dir <- paste0(self$getSnapshotDir(), "-current")
+
+  private$snapshotCount <- private$snapshotCount + 1
+
+  if (is.null(filename)) {
+    filename <- sprintf("%03d.download", private$snapshotCount)
+  }
+
+  # Find the URL to download from (the href of the <a> tag)
+  url <- self$findElement(paste0("#", id))$getAttribute("href")
+
+  req <- httr::GET(url)
+  writeBin(req$content, file.path(current_dir, filename))
+
+  invisible(req$content)
+}
+
 #' Compare current and expected snapshots
 #'
 #' This compares a current and expected snapshot for a test set, and prints

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -83,6 +83,10 @@ codeGenerators <- list(
     )
   },
 
+  fileDownload = function(event) {
+    paste0('app$downloadFile("', event$name, '")')
+  },
+
   outputValue = function(event) {
     paste0('app$snapshot(list(output = "', event$name, '"))')
   },
@@ -178,6 +182,8 @@ shinyApp(
             list(type = "input", name = event$name)
           } else if (type == "fileUpload") {
             list(type = "file-upload", name = event$name)
+          } else if (type == "fileDownload") {
+            list(type = "file-download", name = event$name)
           }
         })
 

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -84,7 +84,7 @@ codeGenerators <- list(
   },
 
   fileDownload = function(event) {
-    paste0('app$downloadFile("', event$name, '")')
+    paste0('app$snapshotDownload("', event$name, '")')
   },
 
   outputValue = function(event) {
@@ -158,10 +158,10 @@ shinyApp(
       file.path(app_dir, "tests", paste0(input$testname, ".R"))
     })
 
-    # Number of snapshot events in input$testevents
+    # Number of snapshot or fileDownload events in input$testevents
     numSnapshots <- reactive({
       snapshots <- vapply(input$testevents, function(event) {
-        return(event$type == "snapshot")
+        return(event$type %in% c("snapshot", "fileDownload"))
       }, logical(1))
 
       sum(snapshots)
@@ -204,7 +204,7 @@ shinyApp(
       stopApp({
         # If no snapshot events occurred, don't write file.
         if (numSnapshots() == 0) {
-          message("No snapshot events occurred, so not saving test code.")
+          message("No snapshot or download events occurred; not saving test code.")
           invisible(list(
             appDir = NULL,
             file = NULL,

--- a/inst/recorder/recorder.js
+++ b/inst/recorder/recorder.js
@@ -1,3 +1,7 @@
+// The content of this file gets injected into the Shiny application that is
+// in the iframe. This is the application for which interactions are being
+// recorded.
+
 window.shinyRecorder = (function() {
     var shinyrecorder = {
         initialized: false,
@@ -20,6 +24,10 @@ window.shinyRecorder = (function() {
 
     $(document).on("shiny:fileuploaded", function(event) {
         sendFileUploadEventToParent(event.name, event.files);
+    });
+
+    $(document).on("shiny:filedownload", function(event) {
+        sendFileDownloadEventToParent(event.name);
     });
 
     // Ctrl-click or Cmd-click (Mac) to record an output value
@@ -45,6 +53,13 @@ window.shinyRecorder = (function() {
         parent.postMessage({
             token: shinyrecorder.token,
             fileUpload: { name: name, files: files }
+        }, "*");
+    }
+
+    function sendFileDownloadEventToParent(name, url) {
+        parent.postMessage({
+            token: shinyrecorder.token,
+            fileDownload: { name: name }
         }, "*");
     }
 

--- a/inst/recorder/www/inject-recorder.js
+++ b/inst/recorder/www/inject-recorder.js
@@ -1,3 +1,5 @@
+// This file is loaded by the recorder app.
+
 window.recorder = (function() {
     var recorder = {
         token: randomId(),
@@ -115,6 +117,18 @@ window.recorder = (function() {
                     type: "fileUpload",
                     name: evt.name,
                     files: evt.files.map(function(file) { return file.name; })
+                });
+
+                // Send updated values to server
+                Shiny.onInputChange("testevents:shinytest.testevents", recorder.testEvents);
+            }
+
+            if (message.fileDownload) {
+                evt = message.fileDownload;
+
+                recorder.testEvents.push({
+                    type: "fileDownload",
+                    name: evt.name
                 });
 
                 // Send updated values to server


### PR DESCRIPTION
This closes #72.

It also requires rstudio/shiny#1559 to be merged so that `recordTest` can record download events. That PR also makes it so shinytest doesn't record the value of a `downloadHandler`, because it changes each time an app is run.