### PR TITLE
initial changes to the recorder for load test

### DIFF
--- a/R/recorder.R
+++ b/R/recorder.R
@@ -2,8 +2,9 @@
 #'
 #' @param app A \code{\link{ShinyDriver}} object, or path to a Shiny application.
 #' @param save_dir A directory to save stuff.
+#' @param load_test A boolean that determines whether or not the resulting test script will be used for load testing
 #' @export
-recordTest <- function(app = ".", save_dir = NULL) {
+recordTest <- function(app = ".", save_dir = NULL, load_test = FALSE) {
 
   # Get the URL for the app. Depending on what type of object `app` is, it may
   # require starting an app.
@@ -40,7 +41,8 @@ recordTest <- function(app = ".", save_dir = NULL) {
   withr::with_options(
     list(
       shinytest.recorder.url = url,
-      shinytest.app.dir = app$getAppDir()
+      shinytest.app.dir = app$getAppDir(),
+      shinytest.load.test = load_test
     ),
     res <- shiny::runApp(system.file("recorder", package = "shinytest"))
   )

--- a/R/recorder.R
+++ b/R/recorder.R
@@ -1,8 +1,10 @@
 #' Launch test event recorder for a Shiny app
 #'
-#' @param app A \code{\link{ShinyDriver}} object, or path to a Shiny application.
+#' @param app A \code{\link{ShinyDriver}} object, or path to a Shiny
+#'   application.
 #' @param save_dir A directory to save stuff.
-#' @param load_test A boolean that determines whether or not the resulting test script will be used for load testing
+#' @param load_test A boolean that determines whether or not the resulting test
+#'   script should be appropriate for load testing
 #' @export
 recordTest <- function(app = ".", save_dir = NULL, load_test = FALSE) {
 

--- a/R/recorder.R
+++ b/R/recorder.R
@@ -3,10 +3,10 @@
 #' @param app A \code{\link{ShinyDriver}} object, or path to a Shiny
 #'   application.
 #' @param save_dir A directory to save stuff.
-#' @param load_test A boolean that determines whether or not the resulting test
-#'   script should be appropriate for load testing
+#' @param load_mode A boolean that determines whether or not the resulting test
+#'   script should be appropriate for load testing.
 #' @export
-recordTest <- function(app = ".", save_dir = NULL, load_test = FALSE) {
+recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE) {
 
   # Get the URL for the app. Depending on what type of object `app` is, it may
   # require starting an app.
@@ -44,7 +44,7 @@ recordTest <- function(app = ".", save_dir = NULL, load_test = FALSE) {
     list(
       shinytest.recorder.url = url,
       shinytest.app.dir = app$getAppDir(),
-      shinytest.load.test = load_test
+      shinytest.load.mode = load_mode
     ),
     res <- shiny::runApp(system.file("recorder", package = "shinytest"))
   )

--- a/man/recordTest.Rd
+++ b/man/recordTest.Rd
@@ -4,12 +4,16 @@
 \alias{recordTest}
 \title{Launch test event recorder for a Shiny app}
 \usage{
-recordTest(app = ".", save_dir = NULL)
+recordTest(app = ".", save_dir = NULL, load_test = FALSE)
 }
 \arguments{
-\item{app}{A \code{\link{ShinyDriver}} object, or path to a Shiny application.}
+\item{app}{A \code{\link{ShinyDriver}} object, or path to a Shiny
+application.}
 
 \item{save_dir}{A directory to save stuff.}
+
+\item{load_test}{A boolean that determines whether or not the resulting test
+script should be appropriate for load testing}
 }
 \description{
 Launch test event recorder for a Shiny app

--- a/man/recordTest.Rd
+++ b/man/recordTest.Rd
@@ -4,7 +4,7 @@
 \alias{recordTest}
 \title{Launch test event recorder for a Shiny app}
 \usage{
-recordTest(app = ".", save_dir = NULL, load_test = FALSE)
+recordTest(app = ".", save_dir = NULL, load_mode = FALSE)
 }
 \arguments{
 \item{app}{A \code{\link{ShinyDriver}} object, or path to a Shiny
@@ -12,8 +12,8 @@ application.}
 
 \item{save_dir}{A directory to save stuff.}
 
-\item{load_test}{A boolean that determines whether or not the resulting test
-script should be appropriate for load testing}
+\item{load_mode}{A boolean that determines whether or not the resulting test
+script should be appropriate for load testing.}
 }
 \description{
 Launch test event recorder for a Shiny app


### PR DESCRIPTION
We want the recorder to be able to generate a script that can be used for load testing. This initial PR does a few things:

- It allows recordTest to be called with an argument, load_test
- If load_test is True, an option is set that the recorder app can pick up
- If load_test is True, the default behavior of the recorder is changed in a few places