### PR TITLE
minor change to set-inputs event logging

### DIFF
--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -18,7 +18,10 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
       " seconds. If this is expected, use `wait_=FALSE, values_=FALSE`, or increase the value of timeout_.")
   }
 
-  self$logEvent("Finished setting inputs", timedout = res$timedOut)
+  self$logEvent("Finished setting inputs",
+    input = paste(names(list(...)), collapse = ","),
+    timedout = res$timedOut
+  )
 
   values <- NULL
   if (values_) {


### PR DESCRIPTION
Adding input name to the finished setting input log event. This makes it much easier to pair up the setting input events, which makes it easier to calculate durations when analyzing the event log.