### PR TITLE
read_error_lines does not work with latest version of processx unless you pass | for stderr

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -103,7 +103,7 @@ sd_startShiny <- function(self, private, path) {
 
   sh <- with_envvar(
     c("R_TESTS" = NA),
-    process$new(commandline = cmd)
+    process$new(commandline = cmd, stderr = "|")
   )
 
   "!DEBUG waiting for shiny to start"

--- a/tests/testthat/test-shiny-driver.R
+++ b/tests/testthat/test-shiny-driver.R
@@ -1,6 +1,11 @@
 
 context("ShinyDriver")
 
+test_that("able to initialize ShinyDriver", {
+  #Very basic check to make sure that we can actually create a ShinyDriver
+  expect_error(ShinyDriver$new(test_path("apps/081-widgets-gallery")), NA)
+})
+
 test_that("getValue", {
 
   app <- ShinyDriver$new(test_path("apps/081-widgets-gallery"))


### PR DESCRIPTION
Fixed a minor error in ```sd_startShiny``` that caused ```recordTest``` to not be able to run, with the latest version of processx at least, exiting with the following error:
```Error in readLines(process_get_error_connection(self, private), ...) : 
  'con' is not a connection```

Added stderr = "|" argument to ```process$new``` to get around this.