### PR TITLE
added functionality to specify loadtimeout in the recordTest function

### DIFF
--- a/R/recorder.R
+++ b/R/recorder.R
@@ -8,7 +8,7 @@
 #' @param seed A random seed to set before running the app. This seed will also
 #'   be used in the test script.
 #' @export
-recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NULL) {
+recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NULL,loadTimeout = 10000) {
 
   # Get the URL for the app. Depending on what type of object `app` is, it may
   # require starting an app.
@@ -26,7 +26,7 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
       }
 
       # It's a path to an app; start the app
-      app <- ShinyDriver$new(app, seed = seed, loadTimeout = 10000)
+      app <- ShinyDriver$new(app, seed = seed, loadTimeout = loadTimeout)
       on.exit({
         rm(app)
         gc()

--- a/docs/reference/recordTest.html
+++ b/docs/reference/recordTest.html
@@ -23,8 +23,8 @@
 <link href="../pkgdown.css" rel="stylesheet">
 <script src="../jquery.sticky-kit.min.js"></script>
 <script src="../pkgdown.js"></script>
-  
-  
+
+
 <!-- mathjax -->
 <script src='https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 
@@ -57,7 +57,7 @@
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
     Articles
-     
+
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu">
@@ -73,12 +73,12 @@
   <a href="../reference/index.html">Reference</a>
 </li>
       </ul>
-      
+
       <ul class="nav navbar-nav navbar-right">
         <li>
   <a href="https://github.com/rstudio/shinytest">
     <span class="fa fa-github fa-lg"></span>
-     
+
   </a>
 </li>
       </ul>
@@ -86,7 +86,7 @@
   </div><!--/.container -->
 </div><!--/.navbar -->
 
-      
+
       </header>
 
       <div class="row">
@@ -95,12 +95,13 @@
     <h1>Launch test event recorder for a Shiny app</h1>
     </div>
 
-    
-    <p>Launch test event recorder for a Shiny app</p>
-    
 
-    <pre class="usage"><span class='fu'>recordTest</span>(<span class='kw'>app</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>save_dir</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>load_mode</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>seed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>)</pre>
-    
+    <p>Launch test event recorder for a Shiny app</p>
+
+
+    <pre class="usage"><span class='fu'>recordTest</span>(<span class='kw'>app</span> <span class='kw'>=</span> <span class='st'>"."</span>, <span class='kw'>save_dir</span> <span class='kw'>=</span> <span class='kw'>NULL</span>, <span class='kw'>load_mode</span> <span class='kw'>=</span> <span class='fl'>FALSE</span>, <span class='kw'>seed</span> <span class='kw'>=</span> <span class='kw'>NULL</span>,
+    <span class='kw'>loadTimeout</span> <span class='kw'>=</span> <span class='kw'>10000</span>)</pre>
+
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a> Arguments</h2>
     <table class="ref-arguments">
     <colgroup><col class="name" /><col class="desc" /></colgroup>
@@ -124,7 +125,7 @@ script should be appropriate for load testing.</p></td>
 be used in the test script.</p></td>
     </tr>
     </table>
-    
+
 
   </div>
   <div class="col-md-3 hidden-xs hidden-sm" id="sidebar">

--- a/man/recordTest.Rd
+++ b/man/recordTest.Rd
@@ -4,7 +4,7 @@
 \alias{recordTest}
 \title{Launch test event recorder for a Shiny app}
 \usage{
-recordTest(app = ".", save_dir = NULL, load_mode = FALSE, seed = NULL)
+recordTest(app = ".", save_dir = NULL, load_mode = FALSE, seed = NULL,loadTimeout=10000)
 }
 \arguments{
 \item{app}{A \code{\link{ShinyDriver}} object, or path to a Shiny


### PR DESCRIPTION
This should fix the error for apps that take longer than 10 seconds to load. 

Error in sd_startShiny(self, private, path, seed) : 
  Cannot find shiny port number. Error:
Running application in test mode.

This fix allows for dynamic load times, but defaults to 10 seconds.