### PR TITLE
Fix error on exit of diff viewer

### DIFF
--- a/R/view-diff.R
+++ b/R/view-diff.R
@@ -99,6 +99,9 @@ viewTestDiffWidget <- function(appDir = ".", testname = NULL) {
 #' @param images Compare screenshot images (only used when \code{interactive} is
 #'   FALSE).
 #'
+#' @return Result of test: "accept" if differences are acceptable, otherwise 
+#' "reject".
+#' 
 #' @seealso \code{\link{textTestDiff}} to get a text diff as a string.
 #'
 #' @import shiny
@@ -114,14 +117,20 @@ viewTestDiff <- function(appDir = ".", testnames = NULL,
 
     message("Differences in current results found for: ", paste(testnames, collapse = " "))
 
+    testResult <- "accept"
+
     for (testname in testnames) {
       message("Viewing diff for ", testname)
-      viewTestDiffSingle(appDir, testname)
+      testResultSingle <- viewTestDiffSingle(appDir, testname)
+      if(testResultSingle == "reject")
+        testResult <- "reject"
     }
 
   } else {
     cat(textTestDiff(appDir, testnames, images))
+    testResult <- "reject"
   }
+  return(testResult)
 }
 
 


### PR DESCRIPTION
I found an error when exiting the interactive diff viewer (either with saving changes or quitting) that a NULL value was being compared with `reject`.  I traced the error back to `viewTestDiff` not returning any value, and so this PR implements those changes.  Can you take a look and see if this behavior is what's desired?