### PR TITLE
Removed .R extension from list$file return value

### DIFF
--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -392,7 +392,7 @@ shinyApp(
 
           invisible(list(
             appDir = app_dir,
-            file = paste0(input$testname, ".R"),
+            file = input$testname,
             run = input$runScript
           ))
         }


### PR DESCRIPTION
The `list$file` was afterwards used for filename checking against no-extension filenames.

This was causing a bug when saving a test in the recorder :
```
Saved test code to .../app/tests/mytest.R
Running mytest.R 
==== Comparing mytest.R... 
  No existing snapshots at mytest.R-expected/. This is a first run of tests.
```
This was due to the fact that res$file is used afterwards to launch the `testApp(appDir = ".", testnames = NULL, ...)` function that expects `testnames` to contain some tests filenames without extension by construction.