### PR TITLE
Allow viewing diff even when shinytest is not imported

### DIFF
--- a/inst/diffviewerapp/app.R
+++ b/inst/diffviewerapp/app.R
@@ -1,5 +1,3 @@
-library(shinytest)
-
 app_dir   <- getOption("shinytest.app.dir")
 test_name <- getOption("shinytest.test.name")
 
@@ -33,13 +31,13 @@ shinyApp(
     ),
     div(
       class = "content",
-      viewTestDiffWidget(app_dir, test_name)
+      shinytest::viewTestDiffWidget(app_dir, test_name)
     )
   ),
 
   server = function(input, output) {
     observeEvent(input$accept, {
-      snapshotUpdate(app_dir, test_name)
+      shinytest::snapshotUpdate(app_dir, test_name)
       stopApp("accept")
     })
 

--- a/inst/diffviewerapp/app.R
+++ b/inst/diffviewerapp/app.R
@@ -1,3 +1,5 @@
+library(shinytest)
+
 app_dir   <- getOption("shinytest.app.dir")
 test_name <- getOption("shinytest.test.name")
 


### PR DESCRIPTION
Running `shinytest::viewTestDiff("~/RStudio/sparklyr/shinytest", "mytest")` triggers:

```
Differences in current results found for: mytest
Viewing diff for mytest
Loading required package: shiny
Error in viewTestDiffWidget(app_dir, test_name) : 
  could not find function "viewTestDiffWidget"
```

We are just missing to import `shinytest` in the Shiny app.