### PR TITLE
Tweak recorder iframe borders

### DIFF
--- a/inst/recorder/www/recorder.css
+++ b/inst/recorder/www/recorder.css
@@ -16,7 +16,8 @@ html,body {
 }
 
 #app-iframe {
-  border: 1px solid black;
+  border: 0px;
+  border-right: solid 1px #d6dadc;
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
Would you be open to tweaking the iframe border color and make it visible only on the right side? I think it looks better:

<img width="1002" alt="screen shot 2018-03-16 at 7 25 39 pm" src="https://user-images.githubusercontent.com/3478847/37550747-d99a6474-294f-11e8-8285-f2b04e5d645e.png">
