### PR TITLE
Translate localhost URLs using rstudioapi if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     htmlwidgets,
     jsonlite,
     withr,
-    httpuv
+    httpuv,
+    rstudioapi (>= 0.8.0.9002)
 Suggests:
     rmarkdown,
     flexdashboard

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,5 +35,7 @@ Imports:
 Suggests:
     rmarkdown,
     flexdashboard
+Remotes:
+    rstudio/rstudioapi
 Encoding: UTF-8
 SystemRequirements: PhantomJS (http://phantomjs.org/)

--- a/R/recorder.R
+++ b/R/recorder.R
@@ -61,6 +61,20 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
     save_dir <- normalizePath(save_dir)
   }
 
+  # Are we running in RStudio? If so, we might need to fix up the URL so that
+  # it's externally accessible.
+  if (rstudioapi::isAvailable()) {
+    if (rstudioapi::hasFun("translateLocalUrl")) {
+      # If the RStudio API knows how to translate URLs, call it.
+      url <- rstudioapi::translateLocalUrl(url, absolute = TRUE)
+    } else if (identical(rstudioapi::versionInfo()$mode, "server")) {
+      # Older versions of the RStudio API don't know how to translate URLs, so
+      # we'll need to do it ourselves if we're in server mode. For example,
+      # http://localhost:1234/ is translated to ../../p/1234/.
+      url <- paste0("../../p/", gsub(".*:([0-9]+)\\/?", "\\1", url), "/")
+    }
+  }
+
   # Use options to pass value to recorder app
   withr::with_options(
     list(

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -292,9 +292,7 @@ shinyApp(
     ),
 
     div(id = "app-iframe-container",
-      # The `data-src` target_url might get rewritten in JS if we're running
-      # in RStudio server, and the result will be the value of `src`.
-      tags$iframe(id = "app-iframe", `data-src` = target_url)
+      tags$iframe(id = "app-iframe", src = target_url)
     ),
     div(id = "shiny-recorder",
       div(class = "shiny-recorder-header", "Test event recorder"),

--- a/inst/recorder/www/inject-recorder.js
+++ b/inst/recorder/www/inject-recorder.js
@@ -10,32 +10,6 @@ window.recorder = (function() {
     // Code injection
     $(document).ready(function() {
 
-        // Modify iframe's URL if we're being proxied by RStudio Server.
-        function fixupIframeUrl() {
-            var $iframe = $("#app-iframe");
-            var orig_src = $iframe.attr("data-src");
-
-            // If this app is NOT proxied by RStudio Server, set the iframe's src to
-            // point to the data-src value.
-            if (! /\/p\/[0-9]+\/$/.test(window.location.href)) {
-                $iframe.attr("src", orig_src);
-                return;
-            }
-
-            // If we are proxied by RStudio Server, rewrite the URL from something like
-            //   http://127.0.0.1:4030
-            // to
-            //   https://username.rstudio.cloud/1234abcd/p/4030/
-            var port = orig_src.replace(/.*:([0-9]+)\/?/, "$1");
-            var new_src = window.location.href.replace(
-                /\/p\/([0-9]+)\/$/,
-                "/p/" + port + "/"
-            );
-
-            $iframe.attr("src", new_src);
-        }
-        fixupIframeUrl();
-
         function evalCodeInFrame(code) {
             var message = {
                 token: "abcdef",


### PR DESCRIPTION
Right now, Shinytest does not work with RStudio Server 1.2 (https://github.com/rstudio/rstudio/issues/4054). This is because it relies on RStudio Server's open port proxying system (i.e. the `/p/1234` URL for connecting to port 1234), which has been removed in RStudio 1.2.

The fix is to remove the JavaScript URL rewriting scheme, and to rewrite the URL ahead of time instead. The development version of the RStudio API has a method for safely generating port proxy URLs; this is used if it's available. If not, we are presumably using RStudio 1.1, and use largely the same regex we did before to reshape the URL in server mode.