### PR TITLE
Allow recording/playing back inputs that do not have a binding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinytest
 Title: Test Shiny Apps
-Version: 1.3.0.9000
+Version: 1.3.0.9001
 Authors@R: c(
     person("Winston", "Chang", role = c("aut", "cre"), email = "winston@rstudio.com"),
     person("Gábor", "Csárdi", role = "aut", email = "gabor@rstudio.com")
@@ -11,7 +11,7 @@ License: MIT + file LICENSE
 LazyData: true
 URL: https://github.com/rstudio/shinytest
 BugReports: https://github.com/rstudio/shinytest/issues
-RoxygenNote: 6.1.0.9000
+RoxygenNote: 6.1.1
 Imports:
     assertthat,
     digest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
-1.3.0.9000
+1.3.0.9001
 ==========
+
+* Added support for setting inputs that do not have an input binding. [#232](https://github.com/rstudio/shinytest/pull/232)
 
 1.3.0
 =====

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,5 +1,5 @@
 sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
-                         timeout_ = 3000) {
+                         timeout_ = 3000, allowInputNoBinding_ = FALSE) {
   if (values_ && !wait_) {
     stop("values_=TRUE and wait_=FALSE are not compatible.",
       "Can't return all values without waiting for update.")
@@ -10,7 +10,7 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
   )
 
   private$queueInputs(...)
-  res <- private$flushInputs(wait_, timeout_)
+  res <- private$flushInputs(wait_, timeout_, allowInputNoBinding_)
 
   if (isTRUE(res$timedOut)) {
     # Get the text from one call back, like "app$setInputs(a=1, b=2)"
@@ -48,16 +48,18 @@ sd_queueInputs <- function(self, private, ...) {
   )
 }
 
-sd_flushInputs <- function(self, private, wait, timeout) {
+sd_flushInputs <- function(self, private, wait, timeout, allowInputNoBinding) {
   private$web$executeScriptAsync(
     "var wait = arguments[0];
     var timeout = arguments[1];
-    var callback = arguments[2];
+    var allowInputNoBinding = arguments[2];
+    var callback = arguments[3];
     shinytest.outputValuesWaiter.start(timeout);
-    shinytest.inputQueue.flush();
+    shinytest.inputQueue.flush(allowInputNoBinding);
     shinytest.outputValuesWaiter.finish(wait, callback);",
     wait,
-    timeout
+    timeout,
+    allowInputNoBinding
   )
 }
 

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -87,6 +87,9 @@
 #'   \item{timeout}{Timeout for the condition, in milliseconds.}
 #'   \item{output}{Character vector, the name(s) of the Shiny output
 #'     widgets that should be updated.}
+#'   \item{allowInputNoBinding_}{When setting the value of an input, allow
+#'     it to set the value of an input even if that input does not have
+#'     an input binding.}
 #'   \item{...}{For \code{expectUpdate} these can be named arguments.
 #'     The argument names correspond to Shiny input widgets: each input
 #'     widget will be set to the specified value.}

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -307,9 +307,10 @@ ShinyDriver <- R6Class(
       sd_expectUpdate(self, private, output, ..., timeout = timeout,
                        iotype = match.arg(iotype)),
 
-    setInputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000) {
+    setInputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000,
+      allowInputNoBinding_ = FALSE) {
       sd_setInputs(self, private, ..., wait_ = wait_, values_ = values_,
-                    timeout_ = timeout_)
+                   timeout_ = timeout_, allowInputNoBinding_ = allowInputNoBinding_)
     },
 
     uploadFile = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000)
@@ -379,8 +380,8 @@ ShinyDriver <- R6Class(
     queueInputs = function(...)
       sd_queueInputs(self, private, ...),
 
-    flushInputs = function(wait = TRUE, timeout = 1000)
-      sd_flushInputs(self, private, wait, timeout),
+    flushInputs = function(wait = TRUE, timeout = 1000, allowInputNoBinding = FALSE)
+      sd_flushInputs(self, private, wait, timeout, allowInputNoBinding),
 
     getTestSnapshotUrl = function(input = TRUE, output = TRUE,
       export = TRUE, format = "json")

--- a/docs/articles/faq.html
+++ b/docs/articles/faq.html
@@ -6,14 +6,14 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Frequently Asked Questions • shinytest</title>
-<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
+<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
 <script src="../pkgdown.js"></script><link href="../extra.css" rel="stylesheet">
 <meta property="og:title" content="Frequently Asked Questions">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">shinytest</a>
-        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9001</span>
       </span>
     </div>
 
@@ -119,8 +119,8 @@
 <div id="how-can-my-app-detect-if-its-running-in-shinytest" class="section level2">
 <h2 class="hasAnchor">
 <a href="#how-can-my-app-detect-if-its-running-in-shinytest" class="anchor"></a>How can my app detect if it’s running in shinytest?</h2>
-<p>Sometimes it can be useful to alter the behavior of your application when it’s being tested. To detect when it’s being tested, you can use <code>isTRUE(getOption("shiny.testmode"))</code>, as in:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="cf">if</span> (<span class="kw">isTRUE</span>(<span class="kw">getOption</span>(<span class="st">"shiny.testmode"</span>))) {</a>
+<p>Sometimes it can be useful to alter the behavior of your application when it’s being tested. To detect when it’s being tested, you can use <code><a href="https://www.rdocumentation.org/packages/base/topics/Logic">isTRUE(getOption("shiny.testmode"))</a></code>, as in:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="cf">if</span> (<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Logic">isTRUE</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/options">getOption</a></span>(<span class="st">"shiny.testmode"</span>))) {</a>
 <a class="sourceLine" id="cb2-2" data-line-number="2">   <span class="co"># Do something special here</span></a>
 <a class="sourceLine" id="cb2-3" data-line-number="3">}</a></code></pre></div>
 </div>
@@ -129,7 +129,7 @@
 <a href="#can-i-modify-the-output-and-input-values-that-are-recorded-in-snapshots" class="anchor"></a>Can I modify the output and input values that are recorded in snapshots?</h2>
 <p>For some kinds of outputs, it is problematic to record the raw value directly in a JSON snapshot. The output might be very large (e.g., image data or a large table), or it may contain randomly-generated values for which the specific value is unimportant for testing (such as randomly-generated DOM element IDs).</p>
 <p>In these situations, you can use an <em>output preprocessor</em> function. This is most commonly done by the author of component used in an application, although it can also be done by an application author. An output preprocessor function is passed an object representing the output value, and it should return a value. If the problem is that the value is large, the preprocessor function can modify the value by hashing it and returning the hash. If the problem is that the value contains some random values, the preprocessor function can replace the random values with fixed ones.</p>
-<p>To add an output preprocessor, use <code><a href="http://www.rdocumentation.org/packages/shiny/topics/snapshotPreprocessOutput">shiny::snapshotPreprocessOutput()</a></code> to modify an output renderer. For example, see <a href="https://github.com/rstudio/shiny/blob/81cc7c5/R/shinywrappers.R#L656-L663">this section</a> of the <code>renderDataTable()</code> function. It takes the object that <em>would be</em> returned by <code>renderDataTable()</code>, and modifies it by adding an output preprocessor which removes strings that contain random values.</p>
+<p>To add an output preprocessor, use <code><a href="https://www.rdocumentation.org/packages/shiny/topics/snapshotPreprocessOutput">shiny::snapshotPreprocessOutput()</a></code> to modify an output renderer. For example, see <a href="https://github.com/rstudio/shiny/blob/81cc7c5/R/shinywrappers.R#L656-L663">this section</a> of the <code>renderDataTable()</code> function. It takes the object that <em>would be</em> returned by <code>renderDataTable()</code>, and modifies it by adding an output preprocessor which removes strings that contain random values.</p>
 <p>For some outputs (notably htmlwidgets), the output value is text string containing JSON, and if you want to modify the JSON, you will have to either (1) do text processing on the JSON, or (2) convert the JSON to an R object, modify the R object, and convert the R object back to JSON. The plotly R package uses this method in <a href="https://github.com/ropensci/plotly/blob/2eef4ab/R/shiny.R#L46-L53"><code>renderPlotly()</code></a>.</p>
 <p>The examples above modify the output renderer from inside the output renderer function, and this would have to be done by the author of the component. It is also possible for an application author to modify a renderer with something like the following:</p>
 <div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="kw">shinyApp</span>(</a>
@@ -139,10 +139,10 @@
 <a class="sourceLine" id="cb3-5" data-line-number="5">  <span class="dt">server =</span> <span class="cf">function</span>(input, output, session) {</a>
 <a class="sourceLine" id="cb3-6" data-line-number="6">    output<span class="op">$</span>random &lt;-<span class="st"> </span><span class="kw">snapshotPreprocessOutput</span>(</a>
 <a class="sourceLine" id="cb3-7" data-line-number="7">      <span class="kw">renderText</span>({</a>
-<a class="sourceLine" id="cb3-8" data-line-number="8">        <span class="kw">paste</span>(<span class="st">"This is a random number:"</span>, <span class="kw">rnorm</span>(<span class="dv">1</span>))</a>
+<a class="sourceLine" id="cb3-8" data-line-number="8">        <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/paste">paste</a></span>(<span class="st">"This is a random number:"</span>, <span class="kw"><a href="https://www.rdocumentation.org/packages/stats/topics/Normal">rnorm</a></span>(<span class="dv">1</span>))</a>
 <a class="sourceLine" id="cb3-9" data-line-number="9">      }),</a>
 <a class="sourceLine" id="cb3-10" data-line-number="10">      <span class="cf">function</span>(value) {</a>
-<a class="sourceLine" id="cb3-11" data-line-number="11">        <span class="kw">sub</span>(<span class="st">"[0-9.]+$"</span>, <span class="st">"&lt;a random number&gt;"</span>, value)</a>
+<a class="sourceLine" id="cb3-11" data-line-number="11">        <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/grep">sub</a></span>(<span class="st">"[0-9.]+$"</span>, <span class="st">"&lt;a random number&gt;"</span>, value)</a>
 <a class="sourceLine" id="cb3-12" data-line-number="12">      }</a>
 <a class="sourceLine" id="cb3-13" data-line-number="13">    )</a>
 <a class="sourceLine" id="cb3-14" data-line-number="14">  }</a>
@@ -152,7 +152,7 @@
 <a class="sourceLine" id="cb4-2" data-line-number="2">    <span class="dt">"random"</span><span class="fu">:</span> <span class="st">"This is a random number: &lt;a random number&gt;"</span></a>
 <a class="sourceLine" id="cb4-3" data-line-number="3">  <span class="fu">}</span></a></code></pre></div>
 <p>(This example is just for illustration purposes. Note that for this example, the screenshots will still change each time the test is run, so there are better solutions, like <a href="in-depth.html#controlling-randomness">setting the random seed</a>.)</p>
-<p>Input values can face the same issues, and they can also be modified with <code><a href="http://www.rdocumentation.org/packages/shiny/topics/snapshotPreprocessInput">shiny::snapshotPreprocessInput()</a></code>.</p>
+<p>Input values can face the same issues, and they can also be modified with <code><a href="https://www.rdocumentation.org/packages/shiny/topics/snapshotPreprocessInput">shiny::snapshotPreprocessInput()</a></code>.</p>
 </div>
   </div>
 
@@ -176,9 +176,8 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
-
       </footer>
 </div>
 

--- a/docs/articles/in-depth.html
+++ b/docs/articles/in-depth.html
@@ -6,14 +6,14 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Testing in depth • shinytest</title>
-<!-- jquery --><script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script><!-- Bootstrap --><link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script><!-- Font Awesome icons --><link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
-<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
+<!-- jquery --><script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script><!-- Bootstrap --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script><!-- Font Awesome icons --><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous">
+<!-- clipboard.js --><script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script><!-- sticky kit --><script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script><!-- pkgdown --><link href="../pkgdown.css" rel="stylesheet">
 <script src="../pkgdown.js"></script><link href="../extra.css" rel="stylesheet">
 <meta property="og:title" content="Testing in depth">
 <meta property="og:description" content="">
 <meta name="twitter:card" content="summary">
-<!-- mathjax --><script src="https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script><!--[if lt IE 9]>
+<!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script><script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script><!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
 <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 <![endif]-->
@@ -31,7 +31,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">shinytest</a>
-        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9001</span>
       </span>
     </div>
 
@@ -117,8 +117,8 @@
 <a class="sourceLine" id="cb1-3" data-line-number="3">app &lt;-<span class="st"> </span>ShinyDriver<span class="op">$</span><span class="kw">new</span>(<span class="st">".."</span>)</a>
 <a class="sourceLine" id="cb1-4" data-line-number="4">app<span class="op">$</span><span class="kw">snapshotInit</span>(<span class="st">"mytest"</span>)</a></code></pre></div>
 <p>Next, it defines some interactions with the application and takes snapshots.</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>))</a>
-<a class="sourceLine" id="cb2-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>))</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
 <a class="sourceLine" id="cb2-3" data-line-number="3">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">action =</span> <span class="st">"click"</span>)</a>
 <a class="sourceLine" id="cb2-4" data-line-number="4">app<span class="op">$</span><span class="kw">snapshot</span>()</a>
 <a class="sourceLine" id="cb2-5" data-line-number="5"></a>
@@ -130,16 +130,16 @@
 <a href="#setting-inputs-with-appsetinputs" class="anchor"></a>Setting inputs with <code>app$setInputs()</code>
 </h3>
 <p>With <code>app$setInputs()</code>, you provide the name of one or more inputs and corresponding values to set them to. Consider this set of directives:</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>))</a>
-<a class="sourceLine" id="cb3-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>))</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
 <a class="sourceLine" id="cb3-3" data-line-number="3">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">action =</span> <span class="st">"click"</span>)</a></code></pre></div>
-<p>Notice that we set the value of <code>checkGroup</code> two times in a row. When we recorded this test script, it started with the value <code>"1"</code>, and then we checked the <code>"2"</code> and <code>"3"</code> boxes. The recorded script set the value to <code>c("1", "2")</code>, and then <code>c("1", "2", "3")</code>. The <code>c("1", "2")</code> value was simply an intermediate step.</p>
+<p>Notice that we set the value of <code>checkGroup</code> two times in a row. When we recorded this test script, it started with the value <code>"1"</code>, and then we checked the <code>"2"</code> and <code>"3"</code> boxes. The recorded script set the value to <code><a href="https://www.rdocumentation.org/packages/base/topics/c">c("1", "2")</a></code>, and then <code><a href="https://www.rdocumentation.org/packages/base/topics/c">c("1", "2", "3")</a></code>. The <code><a href="https://www.rdocumentation.org/packages/base/topics/c">c("1", "2")</a></code> value was simply an intermediate step.</p>
 <p>It’s possible to simplify and speed up the tests by dropping the intermediate step, which leaves us with this:</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>))</a>
 <a class="sourceLine" id="cb4-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">action =</span> <span class="st">"click"</span>)</a></code></pre></div>
 <p>And it’s also possible to set <code>action</code> in the same call, resulting in this:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(</a>
-<a class="sourceLine" id="cb5-2" data-line-number="2">  <span class="dt">checkGroup =</span> <span class="kw">c</span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>),</a>
+<a class="sourceLine" id="cb5-2" data-line-number="2">  <span class="dt">checkGroup =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"1"</span>, <span class="st">"2"</span>, <span class="st">"3"</span>),</a>
 <a class="sourceLine" id="cb5-3" data-line-number="3">  <span class="dt">action =</span> <span class="st">"click"</span></a>
 <a class="sourceLine" id="cb5-4" data-line-number="4">)</a></code></pre></div>
 <p>This will set the values of inputs simultaneously, which will make the tests run faster.</p>
@@ -160,17 +160,17 @@
 <p>If you want to disable screenshots for a single snapshot, you can use:</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">screenshot =</span> <span class="ot">FALSE</span>)</a></code></pre></div>
 <p>If you want more targeted tests, you can snapshot specific items with the <code>items</code> argument. For example, to capture the value of just the outputs named <code>"a"</code> and <code>"b"</code>, you would call:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw">list</span>(<span class="dt">output =</span> <span class="kw">c</span>(<span class="st">"a"</span>, <span class="st">"b"</span>)))</a></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">output =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"a"</span>, <span class="st">"b"</span>)))</a></code></pre></div>
 <p>The value passed to <code>items</code> is a named list, where the <code>output</code> is a character vector with the names of outputs to snapshot. You could also capture specific inputs or exports:</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw">list</span>(</a>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(</a>
 <a class="sourceLine" id="cb10-2" data-line-number="2">  <span class="dt">input =</span> <span class="st">"n"</span>,</a>
-<a class="sourceLine" id="cb10-3" data-line-number="3">  <span class="dt">output =</span> <span class="kw">c</span>(<span class="st">"a"</span>, <span class="st">"b"</span>),</a>
-<a class="sourceLine" id="cb10-4" data-line-number="4">  <span class="dt">export =</span> <span class="kw">c</span>(<span class="st">"e1"</span>, <span class="st">"e2"</span>)</a>
+<a class="sourceLine" id="cb10-3" data-line-number="3">  <span class="dt">output =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"a"</span>, <span class="st">"b"</span>),</a>
+<a class="sourceLine" id="cb10-4" data-line-number="4">  <span class="dt">export =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(<span class="st">"e1"</span>, <span class="st">"e2"</span>)</a>
 <a class="sourceLine" id="cb10-5" data-line-number="5">))</a></code></pre></div>
 <p>Finally, if you want to snapshot all outputs but no inputs or exports, you can simply set <code>output</code> to <code>TRUE</code>:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw">list</span>(<span class="dt">output =</span> <span class="ot">TRUE</span>))</a></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">output =</span> <span class="ot">TRUE</span>))</a></code></pre></div>
 <p>The same can be used to snapshot all inputs and/or all exports. To capture all outputs and exports, but no inputs:</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw">list</span>(<span class="dt">output =</span> <span class="ot">TRUE</span>, <span class="dt">export =</span> <span class="ot">TRUE</span>))</a></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">app<span class="op">$</span><span class="kw">snapshot</span>(<span class="dt">items =</span> <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/list">list</a></span>(<span class="dt">output =</span> <span class="ot">TRUE</span>, <span class="dt">export =</span> <span class="ot">TRUE</span>))</a></code></pre></div>
 </div>
 <div id="exported-values" class="section level3">
 <h3 class="hasAnchor">
@@ -184,11 +184,11 @@
 <a class="sourceLine" id="cb13-5" data-line-number="5">    <span class="kw">verbatimTextOutput</span>(<span class="st">"sum"</span>, <span class="dt">placeholder =</span> <span class="ot">TRUE</span>)</a>
 <a class="sourceLine" id="cb13-6" data-line-number="6">  ),</a>
 <a class="sourceLine" id="cb13-7" data-line-number="7">  <span class="cf">function</span>(input, output, session) {</a>
-<a class="sourceLine" id="cb13-8" data-line-number="8">    nums &lt;-<span class="st"> </span><span class="kw">numeric</span>()</a>
+<a class="sourceLine" id="cb13-8" data-line-number="8">    nums &lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/numeric">numeric</a></span>()</a>
 <a class="sourceLine" id="cb13-9" data-line-number="9"></a>
 <a class="sourceLine" id="cb13-10" data-line-number="10">    c_sum &lt;-<span class="st"> </span><span class="kw">eventReactive</span>(input<span class="op">$</span>add, {</a>
-<a class="sourceLine" id="cb13-11" data-line-number="11">      nums &lt;&lt;-<span class="st"> </span><span class="kw">c</span>(nums, input<span class="op">$</span>n)</a>
-<a class="sourceLine" id="cb13-12" data-line-number="12">      <span class="kw">sum</span>(nums)</a>
+<a class="sourceLine" id="cb13-11" data-line-number="11">      nums &lt;&lt;-<span class="st"> </span><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/c">c</a></span>(nums, input<span class="op">$</span>n)</a>
+<a class="sourceLine" id="cb13-12" data-line-number="12">      <span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/sum">sum</a></span>(nums)</a>
 <a class="sourceLine" id="cb13-13" data-line-number="13">    })</a>
 <a class="sourceLine" id="cb13-14" data-line-number="14"></a>
 <a class="sourceLine" id="cb13-15" data-line-number="15">    output<span class="op">$</span>sum &lt;-<span class="st"> </span><span class="kw">renderText</span>({</a>
@@ -219,8 +219,8 @@
 <div id="adding-delays" class="section level3">
 <h3 class="hasAnchor">
 <a href="#adding-delays" class="anchor"></a>Adding delays</h3>
-<p>In some cases, you may need to wait for some amount of time between steps. You can do this by adding <code>Sys.sleep()</code> in your script. For example:</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="kw">Sys.sleep</span>(<span class="fl">0.5</span>)</a></code></pre></div>
+<p>In some cases, you may need to wait for some amount of time between steps. You can do this by adding <code><a href="https://www.rdocumentation.org/packages/base/topics/Sys.sleep">Sys.sleep()</a></code> in your script. For example:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Sys.sleep">Sys.sleep</a></span>(<span class="fl">0.5</span>)</a></code></pre></div>
 </div>
 <div id="controlling-randomness" class="section level3">
 <h3 class="hasAnchor">
@@ -273,10 +273,10 @@
 <h3 class="hasAnchor">
 <a href="#getting-input-output-and-export-values" class="anchor"></a>Getting input, output, and export values</h3>
 <p>It can also be useful to get the current input, output, and export values. As with screenshots, this is something that <code>app$snapshot()</code> does, but we don’t want to call that function because increments the snapshot counter.</p>
-<p>To fetch all values, you can call <code>app$getAllValues()</code>. This returns a list, which you can inspect with the <code>str()</code> function. It may look something like this:</p>
+<p>To fetch all values, you can call <code>app$getAllValues()</code>. This returns a list, which you can inspect with the <code><a href="https://www.rdocumentation.org/packages/utils/topics/str">str()</a></code> function. It may look something like this:</p>
 <div class="sourceCode" id="cb24"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb24-1" data-line-number="1">vals &lt;-<span class="st"> </span>app<span class="op">$</span><span class="kw">getAllValues</span>()</a>
 <a class="sourceLine" id="cb24-2" data-line-number="2"></a>
-<a class="sourceLine" id="cb24-3" data-line-number="3"><span class="kw">str</span>(vals)</a>
+<a class="sourceLine" id="cb24-3" data-line-number="3"><span class="kw"><a href="https://www.rdocumentation.org/packages/utils/topics/str">str</a></span>(vals)</a>
 <a class="sourceLine" id="cb24-4" data-line-number="4"><span class="co">#&gt; List of 3</span></a>
 <a class="sourceLine" id="cb24-5" data-line-number="5"><span class="co">#&gt;  $ input :List of 4</span></a>
 <a class="sourceLine" id="cb24-6" data-line-number="6"><span class="co">#&gt;   ..$ action    :Classes 'integer', 'shinyActionButtonValue'  int 0</span></a>
@@ -303,7 +303,7 @@
 <a href="#dealing-with-dynamic-data" class="anchor"></a>Dealing with dynamic data</h2>
 <p>If your application uses a data source that changes over time, then a snapshot taken yesterday may not match a snapshot taken today, even if the app itself hasn’t changed. Dynamic data inherently poses a challenge for snapshot-based testing.</p>
 <p>This problem can be avoided by detecting when the application is being tested, and in that case use a static data set instead. To do the detection, you can do something like the following:</p>
-<div class="sourceCode" id="cb26"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb26-1" data-line-number="1"><span class="cf">if</span> (<span class="kw">isTRUE</span>(<span class="kw">getOption</span>(<span class="st">"shiny.testmode"</span>))) {</a>
+<div class="sourceCode" id="cb26"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb26-1" data-line-number="1"><span class="cf">if</span> (<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/Logic">isTRUE</a></span>(<span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/options">getOption</a></span>(<span class="st">"shiny.testmode"</span>))) {</a>
 <a class="sourceLine" id="cb26-2" data-line-number="2">  <span class="co"># Load static/dummy data here</span></a>
 <a class="sourceLine" id="cb26-3" data-line-number="3">} <span class="cf">else</span> {</a>
 <a class="sourceLine" id="cb26-4" data-line-number="4">  <span class="co"># Load normal dynamic data here</span></a>
@@ -315,9 +315,20 @@
 <div id="inputs-without-input-bindings" class="section level3">
 <h3 class="hasAnchor">
 <a href="#inputs-without-input-bindings" class="anchor"></a>Inputs without input bindings</h3>
-<p>Some components for Shiny can set input values directly in their JavaScript code, without going through something called an <em>input binding</em>. Because shinytest sets input values via input bindings, it will not be able to play back inputs for components like these. This is true for some <a href="http://www.htmlwidgets.org/">htmlwidgets</a>, such as <a href="http://rstudio.github.io/DT/">DT</a>. Another case is when plot interactions, such as clicking and brushing, are used with <code>renderPlot()</code> – the clicking and brushing events cannot be played back with shinytest at this time.</p>
-<p>If you record a test with components like these, you may see lines like the following in the generated test script.</p>
-<div class="sourceCode" id="cb27"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb27-1" data-line-number="1"><span class="co"># Input 'dt_rows_selected' was set, but doesn't have an input binding.</span></a></code></pre></div>
+<p>Most input components in Shiny set their values by communicating through something called an <em>input binding</em>. Shinytest works well with input values that are set via input bindings.</p>
+<p>However, there are some components that set input values without using an input binding. These include some <a href="http://www.htmlwidgets.org/">htmlwidgets</a>, such as <a href="http://rstudio.github.io/DT/">DT</a> and <a href="https://github.com/ropensci/plotly/">plotly</a>, as well as Shiny’s built-in plot interactions with <code>renderPlot()</code>.</p>
+<p>As of shinytest 1.3.0.9001, inputs without a binding can be recorded and replayed, although with some limitations. (Prior to that version, inputs without a binding could not be recorded or replated at all.)</p>
+<p>To enable recording of these inputs in the recorder, you must enable the option labeled <em>Save inputs that do not have a binding</em>. The resulting test script code will look something like this:</p>
+<div class="sourceCode" id="cb27"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb27-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">table_rows_selected =</span> <span class="dv">1</span>, <span class="dt">allowInputNoBinding_ =</span> <span class="ot">TRUE</span>)</a>
+<a class="sourceLine" id="cb27-2" data-line-number="2">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">table_row_last_clicked =</span> <span class="dv">1</span>, <span class="dt">allowInputNoBinding_ =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
+<p>Note: If you don’t enable that option, you will see this:</p>
+<div class="sourceCode" id="cb28"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb28-1" data-line-number="1"><span class="co"># Input 'table_rows_selected' was set, but doesn't have an input binding.</span></a>
+<a class="sourceLine" id="cb28-2" data-line-number="2"><span class="co"># Input 'table_row_last_clicked' was set, but doesn't have an input binding.</span></a></code></pre></div>
+<p>When the test script is replayed, the headless browser will set these inputs to the specified values and send them to the server running Shiny in R. However, the browser will not be able to tell the input object to do the exact same behaviors. For example, with DT, when a row is selected, the mouse click event in the browser triggers the DataTable to highlight the row in the browser and also set the input value for Shiny. When shinytest plays the script, it can only do the latter part, setting the input value. The result is that when a screenshot is taken, it won’t have highlighted rows. For components that have internal state that is updated in response to user interaction, that internal state will not be updated when the test script is played. In some cases, this may mean that when the script is played, the behavior when the script is played will not be the same as when a user actually interacts with the application.</p>
+<p>If the input component sets multiple input values (without bindings) in response to a single user event, it may make sense to coalesce them into a single <code>setInputs</code> call, such as this:</p>
+<div class="sourceCode" id="cb29"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb29-1" data-line-number="1">app<span class="op">$</span><span class="kw">setInputs</span>(<span class="dt">table_rows_selected =</span> <span class="dv">1</span>,</a>
+<a class="sourceLine" id="cb29-2" data-line-number="2">              <span class="dt">table_row_last_clicked =</span> <span class="dv">1</span>,</a>
+<a class="sourceLine" id="cb29-3" data-line-number="3">              <span class="dt">allowInputNoBinding_ =</span> <span class="ot">TRUE</span>)</a></code></pre></div>
 </div>
 </div>
 <div id="next" class="section level2">
@@ -350,9 +361,8 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
-
       </footer>
 </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -9,17 +9,17 @@
 <title>Articles • shinytest</title>
 
 <!-- jquery -->
-<script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha384-nrOSfDHtoPMzJHjVTdCopGqIqeYETSXhZDFyniQ8ZHcVy08QesyHcnOUpMpqnmWq" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 <!-- Bootstrap -->
 
-<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha256-916EbMg70RQy9LHiGkXzG8hSg9EdNy97GazNG/aiY1w=" crossorigin="anonymous" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha256-U5ZEeKfGNOja007MMD3YBI0A3OSZOQbeG6z2f2Y0hu8=" crossorigin="anonymous"></script>
 
 <!-- Font Awesome icons -->
-<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha256-eZrrJcwDc/3uDhsdt61sL2oOBY362qM3lon1gyExkL0=" crossorigin="anonymous" />
 
 <!-- clipboard.js -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js" integrity="sha384-cV+rhyOuRHc9Ub/91rihWcGmMmCXDeksTtCihMupQHSsi8GIIRDG0ThDc3HGQFJ3" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js" integrity="sha256-FiZwavyI2V6+EXO1U+xzLG3IKldpiTFf3153ea9zikQ=" crossorigin="anonymous"></script>
 
 <!-- sticky kit -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js" integrity="sha256-c4Rlo1ZozqTPE2RLuvbusY3+SU1pQaJC0TjuhygMipw=" crossorigin="anonymous"></script>
@@ -37,7 +37,8 @@
 
 
 <!-- mathjax -->
-<script src='https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js" integrity="sha256-nvJJv9wWKEm88qvoQl9ekL2J+k/RWIsaSScxxlsrv8k=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-AMS-MML_HTMLorMML.js" integrity="sha256-84DKXVJXs0/F8OTMzX4UR909+jtl4G7SPypPavF+GfA=" crossorigin="anonymous"></script>
 
 <!--[if lt IE 9]>
 <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
@@ -61,7 +62,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">shinytest</a>
-        <span class="label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">1.3.0.9001</span>
       </span>
     </div>
 
@@ -152,9 +153,8 @@
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://pkgdown.r-lib.org/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a> 1.3.0.</p>
 </div>
-
       </footer>
    </div>
 

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -34,16 +34,29 @@ window.shinytest = (function() {
             }
         };
 
-        inputqueue.flush = function() {
-
+        inputqueue.flush = function(allowInputNoBinding) {
             function flushItem(item) {
                 shinytest.log("inputQueue: flushing " + item.name);
                 var binding = findInputBinding(item.name);
-                var value = preprocess(item.name, item.value);
+                if (binding) {
+                    var value = preprocess(item.name, item.value);
+                    var $el = $("#" + escapeSelector(item.name));
 
-                var $el = $("#" + escapeSelector(item.name));
-                binding.setValue($el[0], value);
-                $el.trigger("change");
+                    binding.setValue($el[0], value);
+                    $el.trigger("change");
+
+                } else {
+                    // For inputs without a binding: if the script says it's
+                    // OK, just set the value directly. Otherwise throw an
+                    // error.
+                    if (allowInputNoBinding) {
+                        Shiny.onInputChange(item.name, item.value);
+                    } else {
+                        var msg = "Unable to find input binding for element with id " + item.name;
+                        shinytest.log("  " + msg);
+                        throw msg;
+                    }
+                }
             }
 
             try {
@@ -97,13 +110,11 @@ window.shinytest = (function() {
         };
 
         // Given a DOM ID, return the input binding for that element; if not
-        // found, throw an error.
+        // found, return null.
         function findInputBinding(id) {
             var $el = $("#" + escapeSelector(id));
             if ($el.length === 0 || !$el.data("shinyInputBinding")) {
-                var msg = "Unable to find input binding for element with id " + id;
-                shinytest.log("  " + msg);
-                throw msg;
+                return null;
             }
 
             return $el.data("shinyInputBinding");
@@ -114,6 +125,10 @@ window.shinytest = (function() {
         // preprocessor, simply return the value.
         function preprocess(id, value) {
             var binding = findInputBinding(id);
+            if (!binding) {
+                return value;
+            }
+
             var $el = $("#" + escapeSelector(id));
 
             if (inputqueue.preprocessors[binding.name])

--- a/man/ShinyDriver.Rd
+++ b/man/ShinyDriver.Rd
@@ -95,6 +95,9 @@ app$expectUpdate(output, ..., timeout = 3000,
   \item{timeout}{Timeout for the condition, in milliseconds.}
   \item{output}{Character vector, the name(s) of the Shiny output
     widgets that should be updated.}
+  \item{allowInputNoBinding_}{When setting the value of an input, allow
+    it to set the value of an input even if that input does not have
+    an input binding.}
   \item{...}{For \code{expectUpdate} these can be named arguments.
     The argument names correspond to Shiny input widgets: each input
     widget will be set to the specified value.}

--- a/vignettes/in-depth.Rmd
+++ b/vignettes/in-depth.Rmd
@@ -335,14 +335,35 @@ if (isTRUE(getOption("shiny.testmode"))) {
 
 ### Inputs without input bindings
 
-Some components for Shiny can set input values directly in their JavaScript code, without going through something called an *input binding*. Because shinytest sets input values via input bindings, it will not be able to play back inputs for components like these. This is true for some [htmlwidgets](http://www.htmlwidgets.org/), such as [DT](http://rstudio.github.io/DT/). Another case is when plot interactions, such as clicking and brushing, are used with `renderPlot()` -- the clicking and brushing events cannot be played back with shinytest at this time.
+Most input components in Shiny set their values by communicating through something called an *input binding*. Shinytest works well with input values that are set via input bindings.
 
-If you record a test with components like these, you may see lines like the following in the generated test script.
+However, there are some components that set input values without using an input binding. These include some [htmlwidgets](http://www.htmlwidgets.org/), such as [DT](http://rstudio.github.io/DT/) and [plotly](https://github.com/ropensci/plotly/), as well as Shiny's built-in plot interactions with `renderPlot()`.
+
+As of shinytest 1.3.0.9001, inputs without a binding can be recorded and replayed, although with some limitations. (Prior to that version, inputs without a binding could not be recorded or replated at all.)
+
+To enable recording of these inputs in the recorder, you must enable the option labeled *Save inputs that do not have a binding*. The resulting test script code will look something like this:
 
 ```{r}
-# Input 'dt_rows_selected' was set, but doesn't have an input binding.
+app$setInputs(table_rows_selected = 1, allowInputNoBinding_ = TRUE)
+app$setInputs(table_row_last_clicked = 1, allowInputNoBinding_ = TRUE)
 ```
 
+Note: If you don't enable that option, you will see this:
+
+```{r}
+# Input 'table_rows_selected' was set, but doesn't have an input binding.
+# Input 'table_row_last_clicked' was set, but doesn't have an input binding.
+```
+
+When the test script is replayed, the headless browser will set these inputs to the specified values and send them to the server running Shiny in R. However, the browser will not be able to tell the input object to do the exact same behaviors. For example, with DT, when a row is selected, the mouse click event in the browser triggers the DataTable to highlight the row in the browser and also set the input value for Shiny. When shinytest plays the script, it can only do the latter part, setting the input value. The result is that when a screenshot is taken, it won't have highlighted rows. For components that have internal state that is updated in response to user interaction, that internal state will not be updated when the test script is played. In some cases, this may mean that when the script is played, the behavior when the script is played will not be the same as when a user actually interacts with the application.
+
+If the input component sets multiple input values (without bindings) in response to a single user event, it may make sense to coalesce them into a single `setInputs` call, such as this:
+
+```{r}
+app$setInputs(table_rows_selected = 1,
+              table_row_last_clicked = 1,
+              allowInputNoBinding_ = TRUE)
+```
 
 ## Next
 


### PR DESCRIPTION
This PR adds the ability to record and play back inputs for which there is not an input binding, as is the case with htmlwidgets that have inputs, like DT and plotly.

When playing back, the input value will be set so that the R Shiny process knows about it, but the corresponding object in the browser will not -- so, for example, in the app below, if a row in the DT is selected during the recording phase, it will not be highlighted during playback. For some applications, this is OK, for others it is not.

Example test app with DT:

```R
library(shiny)

ui <- fluidPage(
  numericInput("num", "number", 5),
  DT::dataTableOutput("table"),
  verbatimTextOutput("info")
)

server <- function(input, output, session) {
  output$table <- DT::renderDataTable({
    head(iris, input$num)
  })

  output$info <- renderText({
    paste0(
      "table_rows_selected:    ",  paste(input$table_rows_selected, collapse = ", "), "\n",
      "table_row_last_clicked: ",  paste(input$table_row_last_clicked, collapse = ", "), "\n",
      "table_cell_clicked:     ",  paste(input$table_cell_clicked, collapse = ", "), "\n"
    )
  })
}

shinyApp(ui = ui, server = server)
```

The resulting test script looks like this:

```R
app <- ShinyDriver$new("../")
app$snapshotInit("mytest")

app$setInputs(table_rows_current = c(1, 2, 3, 4, 5), allowInputNoBinding_ = TRUE)
app$setInputs(table_rows_all = c(1, 2, 3, 4, 5), allowInputNoBinding_ = TRUE)
app$setInputs(table_rows_selected = 1, allowInputNoBinding_ = TRUE)
app$setInputs(table_row_last_clicked = 1, allowInputNoBinding_ = TRUE)
app$setInputs(table_cell_clicked = c("1", "5", "setosa"), allowInputNoBinding_ = TRUE)
app$setInputs(table_rows_selected = c(1, 3), allowInputNoBinding_ = TRUE)
app$setInputs(table_row_last_clicked = 3, allowInputNoBinding_ = TRUE)
app$setInputs(table_cell_clicked = c(3, 4, 0.2), allowInputNoBinding_ = TRUE)
app$snapshot()
app$setInputs(table_rows_selected = 1, allowInputNoBinding_ = TRUE)
app$setInputs(table_rows_selected = c(1, 5), allowInputNoBinding_ = TRUE)
app$setInputs(table_row_last_clicked = 5, allowInputNoBinding_ = TRUE)
app$setInputs(table_cell_clicked = c(5, 4, 0.2), allowInputNoBinding_ = TRUE)
app$snapshot()
```

Also note that some of the inputs should really be set simultaneously. I believe that `table_rows_selected`, `table_row_last_clicked`, and `table_cell_clicked` would all be set on the same "tick" of the JS event loop, so they could be coalesced into a single call to `$setInputs()`. It might be possible in the future to automatically detect these cases and coalesce these cases.

cc: @rpodcast, @cpsievert 