### PR TITLE
Record inputs with no binding and event priority

### DIFF
--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -1,5 +1,5 @@
 sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
-                         timeout_ = 3000, allowInputNoBinding_ = FALSE) {
+                         timeout_ = 3000, allowInputNoBinding_ = FALSE, priority_ = c("input", "event")) {
   if (values_ && !wait_) {
     stop("values_=TRUE and wait_=FALSE are not compatible.",
       "Can't return all values without waiting for update.")
@@ -9,7 +9,7 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
     input = paste(names(list(...)), collapse = ",")
   )
 
-  private$queueInputs(...)
+  private$queueInputs(..., priority = priority_)
   res <- private$flushInputs(wait_, timeout_, allowInputNoBinding_)
 
   if (isTRUE(res$timedOut)) {
@@ -38,13 +38,14 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
 
 
 
-sd_queueInputs <- function(self, private, ...) {
+sd_queueInputs <- function(self, private, ..., priority = c("input", "event")) {
   inputs <- list(...)
   assert_that(is_all_named(inputs))
 
   private$web$executeScript(
-    "shinytest.inputQueue.add(arguments[0]);",
-    inputs
+    "shinytest.inputQueue.add(arguments[0], arguments[1]);",
+    inputs,
+    match.arg(priority)
   )
 }
 

--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -5,12 +5,22 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
       "Can't return all values without waiting for update.")
   }
 
+  priority_ <- match.arg(priority_)
+
+  input_values <- lapply(list(...), function(value) {
+    list(
+      value = value,
+      allowInputNoBinding = allowInputNoBinding_,
+      priority = priority_
+    )
+  })
+
   self$logEvent("Setting inputs",
-    input = paste(names(list(...)), collapse = ",")
+    input = paste(names(input_values), collapse = ",")
   )
 
-  private$queueInputs(..., priority = priority_)
-  res <- private$flushInputs(wait_, timeout_, allowInputNoBinding_)
+  private$queueInputs(input_values)
+  res <- private$flushInputs(wait_, timeout_)
 
   if (isTRUE(res$timedOut)) {
     # Get the text from one call back, like "app$setInputs(a=1, b=2)"
@@ -38,29 +48,25 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
 
 
 
-sd_queueInputs <- function(self, private, ..., priority = c("input", "event")) {
-  inputs <- list(...)
+sd_queueInputs <- function(self, private, inputs) {
   assert_that(is_all_named(inputs))
 
   private$web$executeScript(
-    "shinytest.inputQueue.add(arguments[0], arguments[1]);",
-    inputs,
-    match.arg(priority)
+    "shinytest.inputQueue.add(arguments[0]);",
+    inputs
   )
 }
 
-sd_flushInputs <- function(self, private, wait, timeout, allowInputNoBinding) {
+sd_flushInputs <- function(self, private, wait, timeout) {
   private$web$executeScriptAsync(
     "var wait = arguments[0];
     var timeout = arguments[1];
-    var allowInputNoBinding = arguments[2];
-    var callback = arguments[3];
+    var callback = arguments[2];
     shinytest.outputValuesWaiter.start(timeout);
-    shinytest.inputQueue.flush(allowInputNoBinding);
+    shinytest.inputQueue.flush();
     shinytest.outputValuesWaiter.finish(wait, callback);",
     wait,
-    timeout,
-    allowInputNoBinding
+    timeout
   )
 }
 

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -384,8 +384,8 @@ ShinyDriver <- R6Class(
     queueInputs = function(...)
       sd_queueInputs(self, private, ...),
 
-    flushInputs = function(wait = TRUE, timeout = 1000, allowInputNoBinding = FALSE)
-      sd_flushInputs(self, private, wait, timeout, allowInputNoBinding),
+    flushInputs = function(wait = TRUE, timeout = 1000)
+      sd_flushInputs(self, private, wait, timeout),
 
     getTestSnapshotUrl = function(input = TRUE, output = TRUE,
       export = TRUE, format = "json")

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -311,9 +311,10 @@ ShinyDriver <- R6Class(
                        iotype = match.arg(iotype)),
 
     setInputs = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000,
-      allowInputNoBinding_ = FALSE) {
+      allowInputNoBinding_ = FALSE, priority_ = c("input", "event")) {
       sd_setInputs(self, private, ..., wait_ = wait_, values_ = values_,
-                   timeout_ = timeout_, allowInputNoBinding_ = allowInputNoBinding_)
+                   timeout_ = timeout_, allowInputNoBinding_ = allowInputNoBinding_,
+                   priority_ = priority_)
     },
 
     uploadFile = function(..., wait_ = TRUE, values_ = TRUE, timeout_ = 3000)

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -24,12 +24,13 @@ window.shinytest = (function() {
 
         // Add a set of inputs to the queue. Format of `inputs` must be
         // `{ input1: value1, input2: value2 }`.
-        inputqueue.add = function(inputs) {
+        inputqueue.add = function(inputs, priority) {
             for (var name in inputs) {
                 shinytest.log("inputQueue: adding " + name);
                 queue.push({
                     name: name,
-                    value: inputs[name]
+                    value: inputs[name],
+                    priority: priority
                 });
             }
         };

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -50,7 +50,8 @@ window.shinytest = (function() {
                     // OK, just set the value directly. Otherwise throw an
                     // error.
                     if (allowInputNoBinding) {
-                        Shiny.onInputChange(item.name, item.value);
+                        var priority = item.priority === "event" ? {priority: "event"} : undefined;
+                        Shiny.setInputValue(item.name, item.value, priority);
                     } else {
                         var msg = "Unable to find input binding for element with id " + item.name;
                         shinytest.log("  " + msg);

--- a/inst/js/shiny-tracer.js
+++ b/inst/js/shiny-tracer.js
@@ -24,18 +24,20 @@ window.shinytest = (function() {
 
         // Add a set of inputs to the queue. Format of `inputs` must be
         // `{ input1: value1, input2: value2 }`.
-        inputqueue.add = function(inputs, priority) {
+        inputqueue.add = function(inputs) {
             for (var name in inputs) {
                 shinytest.log("inputQueue: adding " + name);
+                var input = inputs[name];
                 queue.push({
                     name: name,
-                    value: inputs[name],
-                    priority: priority
+                    value: input.value,
+                    allowInputNoBinding: input.allowInputNoBinding,
+                    priority: input.priority
                 });
             }
         };
 
-        inputqueue.flush = function(allowInputNoBinding) {
+        inputqueue.flush = function() {
             function flushItem(item) {
                 shinytest.log("inputQueue: flushing " + item.name);
                 var binding = findInputBinding(item.name);
@@ -50,7 +52,7 @@ window.shinytest = (function() {
                     // For inputs without a binding: if the script says it's
                     // OK, just set the value directly. Otherwise throw an
                     // error.
-                    if (allowInputNoBinding) {
+                    if (item.allowInputNoBinding) {
                         var priority = item.priority === "event" ? {priority: "event"} : undefined;
                         Shiny.setInputValue(item.name, item.value, priority);
                     } else {

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -190,6 +190,7 @@ codeGenerators <- list(
     } else {
       if (allowInputNoBinding) {
         args <- paste0(args, ", allowInputNoBinding_ = TRUE")
+        if (identical(event$priority, "event")) args <- paste0(args, ", priority_ = 'event'")
         paste0(
           "app$setInputs(",
           quoteName(event$name), " = ",

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -190,7 +190,7 @@ codeGenerators <- list(
     } else {
       if (allowInputNoBinding) {
         args <- paste0(args, ", allowInputNoBinding_ = TRUE")
-        if (identical(event$priority, "event")) args <- paste0(args, ", priority_ = 'event'")
+        if (identical(event$priority, "event")) args <- paste0(args, ', priority_ = "event"')
         paste0(
           "app$setInputs(",
           quoteName(event$name), " = ",

--- a/inst/recorder/recorder.js
+++ b/inst/recorder/recorder.js
@@ -45,13 +45,15 @@ window.shinyRecorder = (function() {
         }
 
         // Check if value has changed from last time.
-        var valueJSON = JSON.stringify(event.value);
-        if (valueJSON === previousInputValues[event.name])
-            return;
-        previousInputValues[event.name] = valueJSON;
+        if (event.priority !== "event") {
+            var valueJSON = JSON.stringify(event.value);
+            if (valueJSON === previousInputValues[event.name])
+                return;
+            previousInputValues[event.name] = valueJSON;
+        }
 
         var hasBinding = !!event.binding;
-        sendInputEventToParent(event.inputType, event.name, event.value, hasBinding);
+        sendInputEventToParent(event.inputType, event.name, event.value, hasBinding, event.priority);
     });
 
     $(document).on("shiny:filedownload", function(event) {
@@ -82,7 +84,7 @@ window.shinyRecorder = (function() {
         // is possible in principle for other functions to be scheduled to
         // occur afterward, but on the same tick, but in practice this
         // shouldn't occur.)
-        setTimeout(function() { delete updatedInputs[inputId]; }, 0)
+        setTimeout(function() { delete updatedInputs[inputId]; }, 0);
     });
 
     // Ctrl-click or Cmd-click (Mac) to record an output value
@@ -110,14 +112,15 @@ window.shinyRecorder = (function() {
         };
     }
 
-    function sendInputEventToParent(inputType, name, value, hasBinding) {
+    function sendInputEventToParent(inputType, name, value, hasBinding, priority) {
         parent.postMessage({
             token: shinyrecorder.token,
             inputEvent: {
                 inputType: inputType,
                 name: name,
                 value: value,
-                hasBinding: hasBinding
+                hasBinding: hasBinding,
+                priority: priority
              }
         }, "*");
     }

--- a/inst/recorder/www/inject-recorder.js
+++ b/inst/recorder/www/inject-recorder.js
@@ -112,6 +112,7 @@ window.recorder = (function() {
                     name: evt.name,
                     value: evt.value,
                     hasBinding: evt.hasBinding,
+                    priority: evt.priority,
                     time: Date.now()
                 });
 


### PR DESCRIPTION
This PR adds the support for the priority argument of `Shiny.setInputValue()`, which addresses #239