### PR TITLE
Check for top-level tests

### DIFF
--- a/R/test-app.R
+++ b/R/test-app.R
@@ -98,15 +98,24 @@ findTestsDir <- function(appDir) {
     stop("tests/ directory doesn't exist")
   }
 
-  shinytestsDir <- file.path(testsDir, "shinytests")
-  if (dir_exists(shinytestsDir)){
-    return(shinytestsDir)
-  }
-
   r_files <- list.files(testsDir, pattern = "\\.[rR]$", full.names = TRUE)
   is_test <- vapply(r_files, function(f){
     isShinyTest(readLines(f, warn=FALSE))
   }, logical(1))
+
+  shinytestsDir <- file.path(testsDir, "shinytests")
+  if (dir_exists(shinytestsDir)){
+    # We'll want to use this dir. But as a courtesy, let's warn if we find anything
+    # that appears to be a shinytest in the top-level; it's possible that someone
+    # using the old layout (tests at the top-level) might have just had a directory
+    # named shinytests. Let's leave them a clue.
+    if (any(is_test)){
+      warning("Assuming that the shinytests are stored in tests/shinytests, but it appears that there are some ",
+              "shinytests in the top-level tests/ directory. All shinytests should be placed in the tests/shinytests directory.")
+    }
+
+    return(shinytestsDir)
+  }
 
   if (!all(is_test)){
     stop("Found R files that don't appear to be shinytests in the tests/ directory. shinytests should be placed in tests/shinytests/")

--- a/tests/testthat/test-find-tests.R
+++ b/tests/testthat/test-find-tests.R
@@ -24,7 +24,8 @@ test_that("findTestsDir works", {
   expect_match(findTestsDir(test_path("example_test_dirs/nested/")), "/shinytests$")
 
   # Use shinytests if it exists -- even if it's empty
-  expect_match(findTestsDir(test_path("example_test_dirs/empty-nested/")), "/shinytests$")
+  endir <- expect_warning(findTestsDir(test_path("example_test_dirs/empty-nested/")), "there are some shinytests in")
+  expect_match(endir, "/shinytests$")
 
   # Empty top-level is ok
   expect_match(suppressMessages(findTestsDir(test_path("example_test_dirs/empty-toplevel/"))), "/tests$")


### PR DESCRIPTION
Before using the tests/shinytests directory because it exists, do a quick check to see if any of the files in the top-level appear to be shinytests. If so warn, as this might be a mistake.

Based on a suggestion from @shalutiwari when she was reviewing the previous work.

## Validation Steps

Starting with an app that has working shinytests in the top-level `tests/` directory, create a new `tests/shinytests` directory then run the tests again. You should see that we use the (empty) `tests/shinytests` directory, and warn that there are files in the top-level that appear to be shinytests. 

If you copy those working tests into `tests/shinytests`, you should see them running and working, but continue to get the error about shinytests in the top-level.

If you delete the shinytests from the top-level `tests/` directory, the warning should disappear.