### PR TITLE
More complete support for nested test dir.

### DIFF
--- a/R/recorder.R
+++ b/R/recorder.R
@@ -60,7 +60,7 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
 
   # Create directory if needed
   if (is.null(save_dir)) {
-    save_dir <- findTestsDir(app$getAppDir(), must.exist=FALSE)
+    save_dir <- findTestsDir(app$getAppDir(), must.exist=FALSE, doMessage=TRUE)
     if (!dir_exists(save_dir)) {
       dir.create(save_dir, recursive=TRUE)
 

--- a/R/recorder.R
+++ b/R/recorder.R
@@ -60,7 +60,7 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
 
   # Create directory if needed
   if (is.null(save_dir)) {
-    save_dir <- file.path(app$getAppDir(), "tests")
+    save_dir <- findTestsDir(app$getAppDir())
     if (!dir_exists(save_dir)) {
       dir.create(save_dir)
     }

--- a/R/recorder.R
+++ b/R/recorder.R
@@ -60,9 +60,15 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
 
   # Create directory if needed
   if (is.null(save_dir)) {
-    save_dir <- findTestsDir(app$getAppDir())
+    save_dir <- findTestsDir(app$getAppDir(), must.exist=FALSE)
     if (!dir_exists(save_dir)) {
-      dir.create(save_dir)
+      dir.create(save_dir, recursive=TRUE)
+
+      # findTestsDir would return the nested shinytests/ directory if the dir didn't exist,
+      # so since we're creating the nested structure, we should leave behind the top-
+      # level runner, too.
+      runner <- paste0("library(shinytest)\nshinytest::testApp(\"..", .Platform$file.sep, "\")\n")
+      writeLines(runner, file.path(save_dir, "..", "shinytest.R"))
     }
     save_dir <- normalizePath(save_dir)
   }

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -332,6 +332,12 @@ ShinyDriver <- R6Class(
     getAppDir = function()
       sd_getAppDir(self, private),
 
+    getTestsDir = function()
+      sd_getTestsDir(self, private),
+
+    getRelativePathToApp = function()
+      sd_getRelativePathToApp(self, private),
+
     getSnapshotDir = function()
       sd_getSnapshotDir(self, private),
 
@@ -538,6 +544,30 @@ sd_getAppDir <- function(self, private) {
     dirname(private$path)
   else
     private$path
+}
+
+#' Returns NULL if RMD, or the tests/ or tests/shinytests/ dir otherwise, based on
+#' what it finds in each dir.
+sd_getTestsDir <- function(self, private) {
+  # private$path can be a directory (for a normal Shiny app) or path to a .Rmd
+  # file.
+  if (self$isRmd())
+    return(NULL)
+  else
+    findTestsDir(private$path)
+}
+
+# Get the relative path from the test directory to the parent. Since there are currently
+# only two supported test dir options, we can just cheat rather than doing a real path computation
+# between the two paths.
+sd_getRelativePathToApp <- function(self, private){
+  td <- self$getTestsDir()
+  print(td)
+  if (grepl("[/\\\\]shinytest[/\\\\]?", td, perl=TRUE)){
+    return(file.path("..", ".."))
+  } else {
+    return(file.path(".."))
+  }
 }
 
 sd_getSnapshotDir <- function(self, private) {

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -541,7 +541,8 @@ sd_getAppDir <- function(self, private) {
 }
 
 sd_getSnapshotDir <- function(self, private) {
-  file.path(self$getAppDir(), "tests", private$snapshotDir)
+  testDir <- findTestsDir(self$getAppDir())
+  file.path(testDir, private$snapshotDir)
 }
 
 sd_snapshotInit <- function(self, private, path, screenshot) {

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -562,7 +562,6 @@ sd_getTestsDir <- function(self, private) {
 # between the two paths.
 sd_getRelativePathToApp <- function(self, private){
   td <- self$getTestsDir()
-  print(td)
   if (grepl("[/\\\\]shinytest[/\\\\]?", td, perl=TRUE)){
     return(file.path("..", ".."))
   } else {

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -121,8 +121,9 @@ sd_snapshotDownload <- function(self, private, id, filename) {
 snapshotCompare <- function(appDir, testnames = NULL, autoremove = TRUE,
   images = TRUE, quiet = FALSE, interactive = base::interactive()) {
 
+  testDir <- findTestsDir(appDir)
   if (is.null(testnames)) {
-    testnames <- all_testnames(appDir, "-current")
+    testnames <- all_testnames(testDir, "-current")
   }
 
   results <- lapply(
@@ -157,8 +158,9 @@ snapshotCompare <- function(appDir, testnames = NULL, autoremove = TRUE,
 snapshotCompareSingle <- function(appDir, testname, autoremove = TRUE,
   quiet = FALSE, images = TRUE, interactive = base::interactive())
 {
-  current_dir  <- file.path(appDir, "tests", paste0(testname, "-current"))
-  expected_dir <- file.path(appDir, "tests", paste0(testname, "-expected"))
+  testDir <- findTestsDir(appDir)
+  current_dir  <- file.path(testDir, paste0(testname, "-current"))
+  expected_dir <- file.path(testDir, paste0(testname, "-expected"))
 
   # When this function is called from testApp(), this is the way that we get
   # the relative path from the current working dir when testApp() is called.
@@ -284,8 +286,9 @@ snapshotCompareSingle <- function(appDir, testname, autoremove = TRUE,
 #' @inheritParams snapshotCompare
 #' @export
 snapshotUpdate <- function(appDir = ".", testnames = NULL, quiet = FALSE) {
+  testDir <- findTestsDir(appDir)
   if (is.null(testnames)) {
-    testnames <- all_testnames(appDir, "-current")
+    testnames <- all_testnames(testDir, "-current")
   }
 
   for (testname in testnames) {
@@ -298,7 +301,8 @@ snapshotUpdateSingle <- function(appDir = ".", testname, quiet = FALSE) {
   # Strip off trailing slash if present
   testname <- sub("/$", "", testname)
 
-  base_path <- file.path(appDir, "tests", testname)
+  testDir <- findTestsDir(appDir)
+  base_path <- file.path(testDir, testname)
   current_dir  <- paste0(base_path, "-current")
   expected_dir <- paste0(base_path, "-expected")
 

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -86,16 +86,20 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
 #' Prior to 1.3.1.9999, tests were stored directly in `tests/` rather than
 #' nested in `tests/shinytests/`.
 #'
+#' @param must.exist If TRUE, will error if we can't find a test directory.
+#'
 #' This function does the following:
 #'  1. Check to see if `tests/shinytests/` exists. If so, use it.
 #'  2. Check to see if all the top-level R files in `tests/` appear to be shinytests. If
 #'     some are and some aren't, throw an error.
 #'  3. Assuming all top-level R files in `tests/` appear to be shinytests, return that dir.
 #' @noRd
-findTestsDir <- function(appDir) {
+findTestsDir <- function(appDir, must.exist=TRUE) {
   testsDir <- file.path(appDir, "tests")
-  if (!dir_exists(testsDir)){
+  if (!dir_exists(testsDir) && must.exist){
     stop("tests/ directory doesn't exist")
+  } else if (!dir_exists(testsDir) && !must.exist){
+    return(file.path(testsDir, "shinytests"))
   }
 
   r_files <- list.files(testsDir, pattern = "\\.[rR]$", full.names = TRUE)

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -98,15 +98,24 @@ findTestsDir <- function(appDir) {
     stop("tests/ directory doesn't exist")
   }
 
-  shinytestsDir <- file.path(testsDir, "shinytests")
-  if (dir_exists(shinytestsDir)){
-    return(shinytestsDir)
-  }
-
   r_files <- list.files(testsDir, pattern = "\\.[rR]$", full.names = TRUE)
   is_test <- vapply(r_files, function(f){
     isShinyTest(readLines(f, warn=FALSE))
   }, logical(1))
+
+  shinytestsDir <- file.path(testsDir, "shinytests")
+  if (dir_exists(shinytestsDir)){
+    # We'll want to use this dir. But as a courtesy, let's warn if we find anything
+    # that appears to be a shinytest in the top-level; it's possible that someone
+    # using the old layout (tests at the top-level) might have just had a directory
+    # named shinytests. Let's leave them a clue.
+    if (any(is_test)){
+      warning("Assuming that the shinytests are stored in tests/shinytests, but it appears that there are some ",
+              "shinytests in the top-level tests/ directory. All shinytests should be placed in the tests/shinytests directory.")
+    }
+
+    return(shinytestsDir)
+  }
 
   if (!all(is_test)){
     stop("Found R files that don't appear to be shinytests in the tests/ directory. shinytests should be placed in tests/shinytests/")

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -39,7 +39,7 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
     appDir       <- appDir
   }
 
-  testsDir <- findTestsDir(appDir)
+  testsDir <- findTestsDir(appDir, doMessage=TRUE)
   found_testnames <- findTests(testsDir, testnames)
   found_testnames_no_ext <- sub("\\.[rR]$", "", found_testnames)
 
@@ -87,6 +87,8 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
 #' nested in `tests/shinytests/`.
 #'
 #' @param must.exist If TRUE, will error if we can't find a test directory.
+#' @param doMessage If we see that the tests are stored in the top-level tests/ directory as we used to
+#'   recommend, we will note the new recommendation in a message to the user if this is TRUE.
 #'
 #' This function does the following:
 #'  1. Check to see if `tests/shinytests/` exists. If so, use it.
@@ -94,7 +96,7 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
 #'     some are and some aren't, throw an error.
 #'  3. Assuming all top-level R files in `tests/` appear to be shinytests, return that dir.
 #' @noRd
-findTestsDir <- function(appDir, must.exist=TRUE) {
+findTestsDir <- function(appDir, must.exist=TRUE, doMessage=FALSE) {
   testsDir <- file.path(appDir, "tests")
   if (!dir_exists(testsDir) && must.exist){
     stop("tests/ directory doesn't exist")
@@ -125,7 +127,9 @@ findTestsDir <- function(appDir, must.exist=TRUE) {
     stop("Found R files that don't appear to be shinytests in the tests/ directory. shinytests should be placed in tests/shinytests/")
   }
 
-  message("shinytests should be placed in the tests/shinytests directory. Storing them in the top-level tests/ directory will be deprecated in the future.")
+  if (doMessage){
+    message("shinytests should be placed in the tests/shinytests directory. Storing them in the top-level tests/ directory will be deprecated in the future.")
+  }
   testsDir
 }
 

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -158,7 +158,7 @@ findTests <- function(testsDir, testnames=NULL) {
   found_testnames
 }
 
-all_testnames <- function(appDir, suffixes = c("-expected", "-current")) {
+all_testnames <- function(testDir, suffixes = c("-expected", "-current")) {
   # Create a regex string like "(-expected|-current)$"
   pattern <- paste0(
     "(",
@@ -166,14 +166,14 @@ all_testnames <- function(appDir, suffixes = c("-expected", "-current")) {
     ")$"
   )
 
-  testnames <- dir(file.path(appDir, "tests"), pattern = pattern)
+  testnames <- dir(testDir, pattern = pattern)
   testnames <- sub(pattern, "", testnames)
   unique(testnames)
 }
 
 
-validate_testname <- function(appDir, testname) {
-  valid_testnames <- all_testnames(appDir)
+validate_testname <- function(testDir, testname) {
+  valid_testnames <- all_testnames(testDir)
 
   if (is.null(testname) || !(testname %in% valid_testnames)) {
     stop('"', testname, '" ',

--- a/R/view-diff.R
+++ b/R/view-diff.R
@@ -82,8 +82,9 @@ diffviewer_widget <- function(old, new, width = NULL, height = NULL,
 #'
 #' @export
 viewTestDiffWidget <- function(appDir = ".", testname = NULL) {
-  expected <- file.path(appDir, "tests", paste0(testname, "-expected"))
-  current  <- file.path(appDir, "tests", paste0(testname, "-current"))
+  testDir <- findTestsDir(appDir)
+  expected <- file.path(testDir, paste0(testname, "-expected"))
+  current  <- file.path(testDir, paste0(testname, "-current"))
   diffviewer_widget(expected, current)
 }
 
@@ -109,10 +110,11 @@ viewTestDiffWidget <- function(appDir = ".", testname = NULL) {
 viewTestDiff <- function(appDir = ".", testnames = NULL,
   interactive = base::interactive(), images = TRUE)
 {
+  testDir <- findTestsDir(appDir)
   if (interactive) {
     if (is.null(testnames)) {
       # Only try to view diffs if there's a -current dir
-      testnames <- all_testnames(appDir, "-current")
+      testnames <- all_testnames(testDir, "-current")
     }
 
     message("Differences in current results found for: ", paste(testnames, collapse = " "))
@@ -135,7 +137,8 @@ viewTestDiff <- function(appDir = ".", testnames = NULL,
 
 
 viewTestDiffSingle <- function(appDir = ".", testname = NULL) {
-  validate_testname(appDir, testname)
+  testDir <- findTestsDir(appDir)
+  validate_testname(testDir, testname)
 
   withr::with_options(
     list(
@@ -156,8 +159,9 @@ viewTestDiffSingle <- function(appDir = ".", testname = NULL) {
 #' @seealso \code{\link{viewTestDiff}} for interactive diff viewer.
 #' @export
 textTestDiff <- function(appDir = ".", testnames = NULL, images = TRUE) {
+  testDir <- findTestsDir(appDir)
   if (is.null(testnames)) {
-    testnames <- all_testnames(appDir)
+    testnames <- all_testnames(testDir)
   }
 
   diff_results <- lapply(
@@ -188,10 +192,12 @@ textTestDiff <- function(appDir = ".", testnames = NULL, images = TRUE) {
 
 
 textTestDiffSingle <- function(appDir = ".", testname = NULL, images = TRUE) {
-  validate_testname(appDir, testname)
+  testDir <- findTestsDir(appDir)
+  validate_testname(testDir, testname)
 
-  current_dir  <- file.path(appDir, "tests", paste0(testname, "-current"))
-  expected_dir <- file.path(appDir, "tests", paste0(testname, "-expected"))
+  testDir <- findTestsDir(appDir)
+  current_dir  <- file.path(testDir, paste0(testname, "-current"))
+  expected_dir <- file.path(testDir, paste0(testname, "-expected"))
 
   if (dir_exists(expected_dir) && !dir_exists(current_dir)) {
     return(

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -283,8 +283,6 @@ generateTestCode <- function(events, name, seed, useTimes = FALSE,
     if (load_mode) {
       'app <- ShinyLoadDriver$new()'
     } else {
-      print(app$getRelativePathToApp())
-
       paste0(
         # TODO: test with RMD
         # TODO: Windows compat with / sep?

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -167,7 +167,7 @@ codeGenerators <- list(
 
       # Get unescaped filenames in a char vector, with full path
       filepaths <- vapply(event$value, `[[`, "name", FUN.VALUE = "")
-      filepaths <- file.path(findTestsDir(app$getAppDir()), filepaths)
+      filepaths <- file.path(app$getTestsDir(), filepaths)
 
       # Check that all files exist. If not, add a message and don't run test
       # automatically on exit.
@@ -283,9 +283,12 @@ generateTestCode <- function(events, name, seed, useTimes = FALSE,
     if (load_mode) {
       'app <- ShinyLoadDriver$new()'
     } else {
+      print(app$getRelativePathToApp())
 
       paste0(
-        'app <- ShinyDriver$new("', paste("..", app$getAppFilename(), sep = "/"), '"',
+        # TODO: test with RMD
+        # TODO: Windows compat with / sep?
+        'app <- ShinyDriver$new("', paste(app$getRelativePathToApp(), app$getAppFilename(), sep=.Platform$file.sep), '"',
         if (!is.null(seed)) sprintf(", seed = %s", seed),
         if (!is.null(load_timeout)) paste0(", loadTimeout = ", load_timeout),
         if (length(shiny_options) > 0) paste0(", shinyOptions = ", deparse2(shiny_options)),
@@ -408,8 +411,7 @@ shinyApp(
     }
 
     saveFile <- reactive({
-      testDir <- findTestsDir(app$getAppDir())
-      file.path(testDir, paste0(input$testname, ".R"))
+      file.path(app$getTestsDir(), paste0(input$testname, ".R"))
     })
 
     # Number of snapshot or fileDownload events in input$testevents

--- a/inst/recorder/app.R
+++ b/inst/recorder/app.R
@@ -167,14 +167,14 @@ codeGenerators <- list(
 
       # Get unescaped filenames in a char vector, with full path
       filepaths <- vapply(event$value, `[[`, "name", FUN.VALUE = "")
-      filepaths <- file.path(app$getAppDir(), "tests", filepaths)
+      filepaths <- file.path(findTestsDir(app$getAppDir()), filepaths)
 
       # Check that all files exist. If not, add a message and don't run test
       # automatically on exit.
       if (!all(file.exists(filepaths))) {
-        add_dont_run_reason("An uploadFile() must be updated: use the correct path relative to the app's tests/ directory, or copy the file to the app's tests/ directory.")
+        add_dont_run_reason("An uploadFile() must be updated: use the correct path relative to the app's tests/shinytests directory, or copy the file to the app's tests/shinytests directory.")
         code <- paste0(code,
-          " # <-- This should be the path to the file, relative to the app's tests/ directory"
+          " # <-- This should be the path to the file, relative to the app's tests/shinytests directory"
         )
       }
 
@@ -408,7 +408,8 @@ shinyApp(
     }
 
     saveFile <- reactive({
-      file.path(app$getAppDir(), "tests", paste0(input$testname, ".R"))
+      testDir <- findTestsDir(app$getAppDir())
+      file.path(testDir, paste0(input$testname, ".R"))
     })
 
     # Number of snapshot or fileDownload events in input$testevents

--- a/tests/testthat/test-find-tests.R
+++ b/tests/testthat/test-find-tests.R
@@ -24,7 +24,8 @@ test_that("findTestsDir works", {
   expect_match(findTestsDir(test_path("example_test_dirs/nested/")), "/shinytests$")
 
   # Use shinytests if it exists -- even if it's empty
-  expect_match(findTestsDir(test_path("example_test_dirs/empty-nested/")), "/shinytests$")
+  endir <- expect_warning(findTestsDir(test_path("example_test_dirs/empty-nested/")), "there are some shinytests in")
+  expect_match(endir, "/shinytests$")
 
   # Empty top-level is ok
   expect_match(suppressMessages(findTestsDir(test_path("example_test_dirs/empty-toplevel/"))), "/tests$")

--- a/tests/testthat/test-find-tests.R
+++ b/tests/testthat/test-find-tests.R
@@ -32,6 +32,9 @@ test_that("findTestsDir works", {
 
   # Non-shinytest files in the top-level dir cause an error
   expect_error(findTestsDir(test_path("example_test_dirs/mixed-toplevel/")))
+
+  # Unless must-exist is false, in which case it gives us the nested dir optimistically
+  expect_match(findTestsDir(test_path("example_test_dirs/"), must.exist=FALSE), "/shinytests$")
 })
 
 test_that("isShinyTest works", {


### PR DESCRIPTION
Follow-on to #276 which turned out to be incomplete. This finishes up the arc of supporting tests in the `tests/shinytests` directory

## Testing strategy

### Happy path

If you have no `tests/` directory, when you run `recordTest()` you should see:
 - the recorded test stored in `tests/shinytests/mytest.R`, as we now recommend.
 - the test's expectation stored in `tests/shinytests/mytest-expected`.
 - a top-level test runner (currently unused) placed in `tests/shinytest.R` which will later be used by `shiny::testApp()` once that exists.
 - You should now be able to call `shinytest::testApp()` on this application and see the tests working.
 - You can then record more tests (by a different name) and see them and their expectations appear in `tests/shinytests`.

### Old-school

 - If an app followed our previous recommendation and put shinytests in `tests/*.R`, this should continue to work. You can try by running on an app with tests created previously and confirm that `testApp()` still works.
 - You can continue to add tests to an old-school app by running `shinytest::recordtest()`. You should see a warning that we now recommend placing the tests in `tests/shinytests`, but the new tests should be placed in the top-level of `tests/` alongside the existing tests.

### Comments

 - Be aware that the generated shinytest file has a relative reference to where the application's directory is. Previously, that was `../`, but it's now `../../` (since we're two directories away). Be mindful of that when if you try to move your tests around from the old format to the new (or vice versa) since you'll need to adjust that relative path in the `ShinyDriver$new()` call.
 - We have [another PR out](https://github.com/rstudio/shinytest/pull/279) that adds a warning if the `tests/shinytest/` directory exists but the user still appears to have shinytest files in the top-level `tests/` dir. That work is not represented in this PR, so the expectation is that if `tests/shinytests/` exists, that must be the test dir you want to use.
