### PR TITLE
Invert quiet logic

### DIFF
--- a/R/recorder.R
+++ b/R/recorder.R
@@ -60,7 +60,7 @@ recordTest <- function(app = ".", save_dir = NULL, load_mode = FALSE, seed = NUL
 
   # Create directory if needed
   if (is.null(save_dir)) {
-    save_dir <- findTestsDir(app$getAppDir(), mustExist=FALSE, quiet=TRUE)
+    save_dir <- findTestsDir(app$getAppDir(), mustExist=FALSE, quiet=FALSE)
     if (!dir_exists(save_dir)) {
       dir.create(save_dir, recursive=TRUE)
 

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -96,7 +96,7 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
 #'     some are and some aren't, throw an error.
 #'  3. Assuming all top-level R files in `tests/` appear to be shinytests, return that dir.
 #' @noRd
-findTestsDir <- function(appDir, mustExist=TRUE, quiet=FALSE) {
+findTestsDir <- function(appDir, mustExist=TRUE, quiet=TRUE) {
   testsDir <- file.path(appDir, "tests")
   if (!dir_exists(testsDir) && mustExist) {
     stop("tests/ directory doesn't exist")
@@ -115,7 +115,7 @@ findTestsDir <- function(appDir, mustExist=TRUE, quiet=FALSE) {
     # that appears to be a shinytest in the top-level; it's possible that someone
     # using the old layout (tests at the top-level) might have just had a directory
     # named shinytests. Let's leave them a clue.
-    if (any(is_test)) {
+    if (any(is_test) && !quiet) {
       warning("Assuming that the shinytests are stored in tests/shinytests, but it appears that there are some ",
               "shinytests in the top-level tests/ directory. All shinytests should be placed in the tests/shinytests directory.")
     }


### PR DESCRIPTION
Was incompletely reversed when I went from doMessage to !quiet in 723703ad

Now behaves as follows for an app with no `tests/shinytests/` dir:

```
> testApp("~/Temp/shinytestapp/myapp/")
shinytests should be placed in the tests/shinytests directory. Storing them in the top-level tests/ directory will be deprecated in the future.
Running mytest.R
==== Comparing mytest... No changes.
```

And for an app that has spurious shinytest files in the top level but also has a tests/shinytests:

```
> testApp("~/Temp/shinytestapp/myapp/")
Running mytest.R
==== Comparing mytest...
  No existing snapshots at mytest-expected/. This is a first run of tests.

Updating baseline results at ~/Temp/shinytestapp/myapp//tests/shinytests/mytest-expected...
Renaming /Users/jeff/Temp/shinytestapp/myapp/tests/shinytests/mytest-current
      => ~/Temp/shinytestapp/myapp//tests/shinytests/mytest-expected.
Warning message:
In findTestsDir(appDir, quiet = FALSE) :
  Assuming that the shinytests are stored in tests/shinytests, but it appears that there are some shinytests in the top-level tests/ directory. All shinytests should be placed in the tests/shinytests directory.
```