### PR TITLE
Use nested dir if !mustExist and empty top-level

### DIFF
--- a/R/test-app.R
+++ b/R/test-app.R
@@ -101,6 +101,7 @@ findTestsDir <- function(appDir, mustExist=TRUE, quiet=TRUE) {
   if (!dir_exists(testsDir) && mustExist) {
     stop("tests/ directory doesn't exist")
   } else if (!dir_exists(testsDir) && !mustExist) {
+    # Use the preferred directory if nothing exists yet.
     return(file.path(testsDir, "shinytests"))
   }
 
@@ -120,6 +121,12 @@ findTestsDir <- function(appDir, mustExist=TRUE, quiet=TRUE) {
               "shinytests in the top-level tests/ directory. All shinytests should be placed in the tests/shinytests directory.")
     }
 
+    return(shinytestsDir)
+  }
+
+  if (!any(is_test) && !mustExist){
+    # There may be some stuff in the tests directory, but if it's not shinytest-related...
+    # Ignore and just use the nested dir
     return(shinytestsDir)
   }
 

--- a/tests/testthat/example_test_dirs/empty-toplevel/tests/file.R
+++ b/tests/testthat/example_test_dirs/empty-toplevel/tests/file.R
@@ -1,0 +1,1 @@
+# I am not a shiny test.

--- a/tests/testthat/test-find-tests.R
+++ b/tests/testthat/test-find-tests.R
@@ -24,11 +24,13 @@ test_that("findTestsDir works", {
   expect_match(findTestsDir(test_path("example_test_dirs/nested/")), "/shinytests$")
 
   # Use shinytests if it exists -- even if it's empty
-  endir <- expect_warning(findTestsDir(test_path("example_test_dirs/empty-nested/")), "there are some shinytests in")
+  endir <- expect_warning(findTestsDir(test_path("example_test_dirs/empty-nested/"), quiet=FALSE), "there are some shinytests in")
   expect_match(endir, "/shinytests$")
 
-  # Empty top-level is ok
-  expect_match(suppressMessages(findTestsDir(test_path("example_test_dirs/empty-toplevel/"))), "/tests$")
+  # Empty top-level recommends non-existant nested dir if top-level doesn't contain any shinytests
+  expect_match(suppressMessages(findTestsDir(test_path("example_test_dirs/empty-toplevel/"), mustExist=FALSE)), "/tests/shinytests$")
+  # Empty top-level with mustExist=TRUE errors
+  expect_error(findTestsDir(test_path("example_test_dirs/empty-toplevel/"), mustExist=TRUE), "should be placed in tests/shinytests")
 
   # Non-shinytest files in the top-level dir cause an error
   expect_error(findTestsDir(test_path("example_test_dirs/mixed-toplevel/")))


### PR DESCRIPTION
Also add tests to confirm that we prefer nested for !mustExist, but error if we find a messy top-level with no nested dir in mustExist.

Should resolve two reported bugs:

> @jeff Third issue is when I am recording the app with empty tests directory then its creating mytest.R and mytest-expected in tests directory. Why its not creating the correct directory structure then? It should create shinytests directory under tests directory and keep these files in there.

and

> @jeff First issue where only shinytest.R file is there in shinytests (Jeff Note: I think she meant the `tests/` directory based on the output shown below) directory and I am trying to get a new recording. Then recordTest errors out. Expected behavior should be that it should let you create mytest.R file.

```
shalus-MBP:tests shalutiwari$ ls -lrt
total 8
-rw-r--r--  1 shalutiwari  staff  46 Sep 13 10:56 shinytest.R

recordTest('005-sliders')
Error in findTestsDir(app$getAppDir(), mustExist = FALSE, quiet = FALSE) : 
  Found R files that don't appear to be shinytests in the tests/ directory. shinytests should be placed in tests/shinytests/
```

## Validation steps

Install from this branch: `remotes::install_github("rstudio/shinytest@jeff/prefer-nested")`

Acceptance criteria:

1. Record a test on an app with no `tests/` directory. It should create a nested `tests/shinytests` directory and place the test there.
2. Record a test with an empty top-level `tests/` directory. It should create a new `tests/shinytests` directory and store the test there.
3. Record a test with a top-level directory that has some R files that are not shinytests. (e.g. the `shinytest.R` runner that gets created by default). It should create a new `tests/shinytests` directory and store the test there.
4. Record a test with an empty `tests/shinytests` directory and no shinytests in the top-level of `tests/` (you can have other R files, or nothing at all). The tests should be written into `tests/shinytests`.
5. Record a test with an empty `tests/shinytests` but with old shinytests in the top-level. You should see a warning about the confusion that says that we're going to favor `tests/shinytests`.