### PR TITLE
Support being given an appdir that is actually the `tests/` dir

### DIFF
--- a/R/test-app.R
+++ b/R/test-app.R
@@ -97,6 +97,18 @@ testApp <- function(appDir = ".", testnames = NULL, quiet = FALSE,
 #'  3. Assuming all top-level R files in `tests/` appear to be shinytests, return that dir.
 #' @noRd
 findTestsDir <- function(appDir, mustExist=TRUE, quiet=TRUE) {
+  if (basename(appDir) == "tests"){
+    # We were given a */tests/ directory. It's possible that we're in the middle of a nested tests
+    # directory and the application dir is actually one level up. This happens in certain versions
+    # of the RStudio IDE.
+
+    if (!dir_exists(file.path(appDir, "tests"))){
+      # We're in a dir called `tests` and there's not another `tests` directory inside, so we can
+      # assume that the app dir is actually probably one level up.
+      appDir <- dirname(appDir)
+    }
+  }
+
   testsDir <- file.path(appDir, "tests")
   if (!dir_exists(testsDir) && mustExist) {
     stop("tests/ directory doesn't exist")

--- a/R/test-app.R
+++ b/R/test-app.R
@@ -101,6 +101,7 @@ findTestsDir <- function(appDir, mustExist=TRUE, quiet=TRUE) {
     # We were given a */tests/ directory. It's possible that we're in the middle of a nested tests
     # directory and the application dir is actually one level up. This happens in certain versions
     # of the RStudio IDE.
+    # https://github.com/rstudio/rstudio/issues/5677
 
     if (!dir_exists(file.path(appDir, "tests"))){
       # We're in a dir called `tests` and there's not another `tests` directory inside, so we can

--- a/tests/testthat/test-find-tests.R
+++ b/tests/testthat/test-find-tests.R
@@ -37,6 +37,8 @@ test_that("findTestsDir works", {
 
   # Unless must-exist is false, in which case it gives us the nested dir optimistically
   expect_match(findTestsDir(test_path("example_test_dirs/"), mustExist=FALSE), "/shinytests$")
+
+  expect_match(findTestsDir(test_path("example_test_dirs/nested/tests"), mustExist=FALSE), "/nested/tests/shinytests$")
 })
 
 test_that("isShinyTest works", {


### PR DESCRIPTION
This is the current behavior in the RStudio IDE. I believe they must go one directory up from wherever the test got recorded to compute the appdir. Unfortunately, that calculation is no longer correct so we need to make a special case for this.

Closes #293 