### PR TITLE
Normalize reported resolution in PNG header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 * Added new `suffix` option, which allows adding a suffix to an expected results directory. This makes it possible to store multiple sets of results, which can be useful, for example, if you run tests on multiple platforms. ((#295)[https://github.com/rstudio/shinytest/pull/295])
 
+* Previously, on Windows, the reported resolution of screenshots depended on the actual screen resolution. For example, on one Windows machine, it might report a screenshot to be 96 ppi, while on another machine, it might report it to be 240 ppi, even though the image data is exactly the same from the two machines. This caused problems when expected results were generated on one machine and the tests were run on another machine. Now, the screenshots are modified so that they always report 72 ppi resolution, which is the same as on Mac and Linux. ((#297)[https://github.com/rstudio/shinytest/pull/297])
+
 1.3.1
 =======
 

--- a/R/session.R
+++ b/R/session.R
@@ -30,6 +30,12 @@ sd_takeScreenshot <- function(self, private, file) {
   "!DEBUG sd_takeScreenshot"
   self$logEvent("Taking screenshot")
   private$web$takeScreenshot(file)
+
+  # On Windows, need to fix up the PNG resolution header to make it
+  # consistent.
+  if (is_windows()) {
+    normalize_png_res_header(file)
+  }
 }
 
 sd_findElement <- function(self, private, css, linkText,

--- a/R/utils.R
+++ b/R/utils.R
@@ -154,7 +154,6 @@ read_utf8 <- function(file) {
   raw_to_utf8(res)
 }
 
-
 normalize_suffix <- function(suffix) {
   if (is.null(suffix) || suffix == "") {
     ""
@@ -162,3 +161,42 @@ normalize_suffix <- function(suffix) {
     paste0("-", suffix)
   }
 }
+
+# For PhantomJS on Windows, the pHYs (Physical pixel dimensions) header enbeds
+# the computer screen's actual resolution, even though the screenshots are
+# done on a headless browser, and the actual screen resolution has no effect
+# on the pixel-for-pixel content of the screenshot.
+#
+# The header can differ when expected results are generated on one computer
+# and compared to results from another computer, and this causes shinytest to
+# report false positives in changes to screenshots. In order to avoid this
+# problem, this function rewrites the pHYs header to always report a 72 ppi
+# resolution.
+#
+# https://github.com/ariya/phantomjs/issues/10659#issuecomment-14993827
+normalize_png_res_header <- function(file) {
+  data <- readBin(file, raw(), n = 512)
+  header_offset <- grepRaw("pHYs", data)
+
+  if (length(header_offset) == 0) {
+    warning("Cannot find pHYs header in ", basename(file))
+    return(FALSE)
+  }
+
+  # Replace with header specifying 2835 pixels per meter (equivalent to 72
+  # ppi).
+  con <- file(file, open = "r+b")
+  seek(con, header_offset - 1, rw = "write")
+  writeBin(png_res_header_data, con)
+  close(con)
+
+  return(TRUE)
+}
+
+png_res_header_data <- as.raw(c(
+  0x70, 0x48, 0x59, 0x73,  # "pHYs"
+  0x00, 0x00, 0x0b, 0x13,  # Pixels per unit, X: 2835
+  0x00, 0x00, 0x0b, 0x13,  # Pixels per unit, Y: 2835
+  0x01,                    # Unit specifier: meters
+  0x00, 0x9a, 0x9c, 0x18   # Checksum
+))

--- a/inst/diffviewerapp/app.R
+++ b/inst/diffviewerapp/app.R
@@ -2,7 +2,7 @@ app_dir   <- getOption("shinytest.app.dir")
 test_name <- getOption("shinytest.test.name")
 suffix    <- getOption("shinytest.suffix")
 
-msg_suffix <- normalize_suffix(suffix)
+msg_suffix <- shinytest:::normalize_suffix(suffix)
 
 shinyApp(
   ui = bootstrapPage(


### PR DESCRIPTION
Previously, on Windows, the reported resolution of screenshots depended on the actual screen resolution. For example, on one Windows machine, it might report a screenshot to be 96 ppi, while on another machine, it might report it to be 240 ppi, even though the image data is exactly the same from the two machines. This caused problems when expected results were generated on one machine and the tests were run on another machine. Now, the screenshots are modified so that they always report 72 ppi resolution, which is the same as on Mac and Linux.


See https://github.com/ariya/phantomjs/issues/10659#issuecomment-14993827 for more about the issue.