### PR TITLE
Do not retrieve all iotypes within app$waitForValue

### DIFF
--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -508,7 +508,9 @@ sd_waitForValue <- function(self, private, name, ignore = list(NULL, ""), iotype
 
   while (TRUE) {
     value <- try({
-      args <- list()
+      # by default, do not retrieve anything
+      args <- list(input = FALSE, output = FALSE, export = FALSE)
+      # only retrieve `name` from `iotype`
       args[[iotype]] <- name
       do.call(self$getAllValues, args)[[iotype]][[name]]
     }, silent = TRUE)


### PR DESCRIPTION
Followup to #304 

Most likely there will be plots in `output`.  These can be very costly when returning many plots and only needing one of the input values.