### PR TITLE
Remove RStudio Connect Reference

### DIFF
--- a/vignettes/ci.Rmd
+++ b/vignettes/ci.Rmd
@@ -219,12 +219,6 @@ test_that("Application works", {
 
 See the [Using shinytest with R packages](package.html) article.
 
-
-## RStudio Connect
-
-In the coming months, RStudio Connect will have the ability to automatically test Shiny applications.
-
-
 ## Frequently asked questions
 
 ### How do I add a status badge to my project?


### PR DESCRIPTION
This isn't currently on the RStudio Connect roadmap, probably best not to mention here.

Is there anything else I need to do to render to HTML version? Or is that auto-built on deploy?