### PR TITLE
Change writeUTF8 so it doesn't add extra newline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 shinytest 1.4.0.9000
 ===============
 
-* Fixed [#206](https://github.com/rstudio/shinytest/issues/206): On Windows, non-ASCII characters in JSON snapshots were written using the native encoding, instead of UTF-8. ([#318](https://github.com/rstudio/shinytest/pull/318))
+* Fixed [#206](https://github.com/rstudio/shinytest/issues/206): On Windows, non-ASCII characters in JSON snapshots were written using the native encoding, instead of UTF-8. ([#318](https://github.com/rstudio/shinytest/pull/318), [#320](https://github.com/rstudio/shinytest/pull/320))
 
 shinytest 1.4.0
 ===============

--- a/R/snapshot.R
+++ b/R/snapshot.R
@@ -51,7 +51,7 @@ sd_snapshot <- function(self, private, items, filename, screenshot)
   content <- raw_to_utf8(req$content)
   content <- hash_snapshot_image_data(content)
   content <- jsonlite::prettify(content, indent = 2)
-  writeUTF8(content, file.path(current_dir, filename))
+  write_utf8(content, file.path(current_dir, filename))
 
   if (screenshot) {
     # Replace extension with .png
@@ -467,7 +467,7 @@ remove_image_hashes_and_files <- function(filename) {
   } else if (grepl("\\.json$", filename)) {
     content <- read_utf8(filename)
     content <- remove_image_hashes(content)
-    writeUTF8(content, filename)
+    write_utf8(content, filename)
     filename
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -154,6 +154,11 @@ read_utf8 <- function(file) {
   raw_to_utf8(res)
 }
 
+# write text as UTF-8
+write_utf8 <- function(text, ...) {
+  writeBin(charToRaw(enc2utf8(text)), ..., endian = "little")
+}
+
 normalize_suffix <- function(suffix) {
   if (is.null(suffix) || suffix == "") {
     ""
@@ -200,10 +205,3 @@ png_res_header_data <- as.raw(c(
   0x01,                    # Unit specifier: meters
   0x00, 0x9a, 0x9c, 0x18   # Checksum
 ))
-
-
-# write text as UTF-8 copied from shiny
-writeUTF8 <- function(text, ...) {
-  text <- enc2utf8(text)
-  writeLines(text, ..., useBytes = TRUE)
-}


### PR DESCRIPTION
It turns out that the change in #318 added an extra `\n` to JSON output. This PR changes it so that it doesn't add an extra newline, and renames the function to `write_utf8`, so that it's consistent with `read_utf8` in this package. 