### PR TITLE
Update required versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,25 +16,25 @@ BugReports: https://github.com/rstudio/shinytest/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Imports:
-    assertthat,
-    digest,
-    crayon,
-    debugme,
-    parsedate,
-    pingr,
-    callr (>= 2.0.3),
-    R6,
-    rematch,
-    httr,
-    shiny (>= 1.3.2),
-    testthat (>= 1.0.0),
+    assertthat (>= 0.2.1),
+    digest (>= 0.6.25),
+    crayon (>= 1.3.4),
+    debugme (>= 1.1.0),
+    parsedate (>= 1.2.0),
+    pingr (>= 2.0.1),
+    callr (>= 3.4.3),
+    R6 (>= 2.4.1),
+    rematch (>= 1.0.1),
+    httr (>= 1.4.2),
+    shiny (>= 1.5.0),
+    testthat (>= 2.3.2),
     utils,
     webdriver (>= 1.0.5),
-    htmlwidgets,
-    jsonlite,
-    withr,
-    httpuv,
-    rstudioapi (>= 0.8.0.9002)
+    htmlwidgets (>= 1.5.1),
+    jsonlite (>= 1.7.0),
+    withr (>= 2.2.0),
+    httpuv (>= 1.5.4),
+    rstudioapi (>= 0.11)
 Suggests:
     rmarkdown,
     flexdashboard


### PR DESCRIPTION
So that the end user gets latest version of deps when installing shinytest.