### PR TITLE
Allow connecting to an existing Shiny instance

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -4,7 +4,7 @@
 
 sd_initialize <- function(self, private, path, loadTimeout, checkNames,
                           debug, phantomTimeout, seed, cleanLogs,
-                          shinyOptions) {
+                          shinyOptions, url=NULL) {
 
   private$cleanLogs <- cleanLogs
   if (is.null(loadTimeout)) {
@@ -21,9 +21,13 @@ sd_initialize <- function(self, private, path, loadTimeout, checkNames,
   self$logEvent("Getting PhantomJS port")
   private$phantomPort <- get_phantomPort(timeout = phantomTimeout)
 
-  if (grepl("^http(s?)://", path)) {
-    private$setShinyUrl(path)
+  if(!dir_exists(path))
+    stop("No such directory: ", path)
+  private$path = path
 
+  if(!is.null(url)) {
+    "!DEBUG setting URL provided by the user"
+    private$setShinyUrl(url)
   } else {
     "!DEBUG starting shiny app from path"
     self$logEvent("Starting Shiny app")
@@ -247,7 +251,7 @@ find_phantom <- function(quiet = FALSE) {
 sd_finalize <- function(self, private) {
   self$stop()
 
-  if (isTRUE(private$cleanLogs)) {
+  if (!is.null(private$shinyProcess) && isTRUE(private$cleanLogs)) {
     unlink(private$shinyProcess$get_output_file())
     unlink(private$shinyProcess$get_error_file())
   }

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -1,14 +1,17 @@
 #' Class to manage a shiny app and a `phantom.js` headless browser.
 #'
 #' @description
-#' This class starts a Shiny app in a new R session, along with a `phantom.js`
-#' headless browser that can be used to simulate user actions. This provides
-#' a full simulation of a Shiny app so that you can test user interactions
-#' with a live app.
+#'
+#' This class connects a `phantom.js` headless browser to a shiny app to enable
+#' testing the effect of user interactions with a live app.  Specify `url` to
+#' connect to an existing shiny app, or omit `url` and the app located at
+#' `path` will be launched in a separate subprocess.
+#'
+#' This provides a full simulation of a Shiny app so that you can
 #'
 #' @param iotype Type of the Shiny widget. Usually shinytest finds the widgets
-#'   by their name, so this is only needed if you use the same name for an
-#'   input and output widget.
+#'   by their name, so this is only needed if you use the same name for an input
+#'   and output widget.
 #' @param timeout Amount of time to wait before giving up (milliseconds).
 #' @param timeout_ Amount of time to wait before giving up (milliseconds).
 #' @param wait_ Wait until all reactive updates have completed?
@@ -41,14 +44,15 @@ ShinyDriver <- R6Class(
     #' @param cleanLogs Whether to remove the stdout and stderr logs when the
     #'     Shiny process object is garbage collected.
     #' @param shinyOptions A list of options to pass to [shiny::runApp()].
+    #' @param url Optional URL where the shiny app is executing.
     initialize = function(path = ".", loadTimeout = NULL, checkNames = TRUE,
       debug = c("none", "all", shinytest::ShinyDriver$debugLogTypes),
       phantomTimeout = 5000, seed = NULL, cleanLogs = TRUE,
-      shinyOptions = list())
+      shinyOptions = list(), url=NULL)
     {
       sd_initialize(self, private, path, loadTimeout, checkNames, debug,
         phantomTimeout = phantomTimeout, seed = seed, cleanLogs = cleanLogs,
-        shinyOptions = shinyOptions)
+        shinyOptions = shinyOptions, url=url)
     },
 
     #' @description Stop app and clean up logs.

--- a/man/ShinyDriver.Rd
+++ b/man/ShinyDriver.Rd
@@ -4,10 +4,12 @@
 \alias{ShinyDriver}
 \title{Class to manage a shiny app and a \code{phantom.js} headless browser.}
 \description{
-This class starts a Shiny app in a new R session, along with a \code{phantom.js}
-headless browser that can be used to simulate user actions. This provides
-a full simulation of a Shiny app so that you can test user interactions
-with a live app.
+This class connects a \code{phantom.js} headless browser to a shiny app to enable
+testing the effect of user interactions with a live app.  Specify \code{url} to
+connect to an existing shiny app, or omit \code{url} and the app located at
+\code{path} will be launched in a separate subprocess.
+
+This provides a full simulation of a Shiny app so that you can
 }
 \section{Methods}{
 \subsection{Public methods}{
@@ -70,7 +72,8 @@ with a live app.
   phantomTimeout = 5000,
   seed = NULL,
   cleanLogs = TRUE,
-  shinyOptions = list()
+  shinyOptions = list(),
+  url = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -100,6 +103,8 @@ behavior repeatable.}
 Shiny process object is garbage collected.}
 
 \item{\code{shinyOptions}}{A list of options to pass to \code{\link[shiny:runApp]{shiny::runApp()}}.}
+
+\item{\code{url}}{Optional URL where the shiny app is executing.}
 }
 \if{html}{\out{</div>}}
 }
@@ -141,8 +146,8 @@ Finds a widget and queries its value. See the \code{getValue()} method of
 \item{\code{name}}{Name of a shiny widget.}
 
 \item{\code{iotype}}{Type of the Shiny widget. Usually shinytest finds the widgets
-by their name, so this is only needed if you use the same name for an
-input and output widget.}
+by their name, so this is only needed if you use the same name for an input
+and output widget.}
 }
 \if{html}{\out{</div>}}
 }
@@ -165,8 +170,8 @@ plus \code{setValue()}; see the \link{Widget} documentation for more details.
 \item{\code{value}}{New value.}
 
 \item{\code{iotype}}{Type of the Shiny widget. Usually shinytest finds the widgets
-by their name, so this is only needed if you use the same name for an
-input and output widget.}
+by their name, so this is only needed if you use the same name for an input
+and output widget.}
 }
 \if{html}{\out{</div>}}
 }
@@ -525,8 +530,8 @@ has initialized or finished processing a complex reactive situation.
 updates.}
 
 \item{\code{iotype}}{Type of the Shiny widget. Usually shinytest finds the widgets
-by their name, so this is only needed if you use the same name for an
-input and output widget.}
+by their name, so this is only needed if you use the same name for an input
+and output widget.}
 
 \item{\code{timeout}}{Amount of time to wait before giving up (milliseconds).}
 
@@ -617,8 +622,8 @@ Finds the a Shiny input or output control.
 \item{\code{name}}{Name of a shiny widget.}
 
 \item{\code{iotype}}{Type of the Shiny widget. Usually shinytest finds the widgets
-by their name, so this is only needed if you use the same name for an
-input and output widget.}
+by their name, so this is only needed if you use the same name for an input
+and output widget.}
 }
 \if{html}{\out{</div>}}
 }
@@ -653,8 +658,8 @@ For updates that involve a lot of computation, increase the timeout.
 \item{\code{timeout}}{Amount of time to wait before giving up (milliseconds).}
 
 \item{\code{iotype}}{Type of the Shiny widget. Usually shinytest finds the widgets
-by their name, so this is only needed if you use the same name for an
-input and output widget.}
+by their name, so this is only needed if you use the same name for an input
+and output widget.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-specify-url.R
+++ b/tests/testthat/test-specify-url.R
@@ -1,0 +1,21 @@
+test_that("specify url", {
+
+  # Start shiny in one subprocess
+  server <- ShinyDriver$new(test_path("apps/click-me"))
+  server$waitForShiny()
+
+  # Access from another (use a different path to prevent shinytest from trying to double-remove )
+  client <- ShinyDriver$new(test_path("apps/outputs"),
+                            url = server$getUrl()
+                            )
+
+  w <- client$findWidget("click")
+  w$click()
+  w$click()
+
+  client$waitForShiny()
+  expect_equal(client$getValue("i"), "2")
+
+  client$stop()
+  server$stop()
+})

--- a/vignettes/in-depth.Rmd
+++ b/vignettes/in-depth.Rmd
@@ -269,6 +269,32 @@ app <- ShinyDriver$new("path/to/app")
 
 The rest of the test script can be run unchanged.
 
+## Debugging app issues
+
+IF you need to debug an issue in the application that is triggered by a test
+script, you can start the shiny app in one R session, and then run the test
+script in another R session by providing the URL to the ShinyDriver constructor.
+
+For example:
+
+In one R session, set breakpoints and then launch the app it on a
+specific port:
+```{r}
+shiny::runApp(".", port=4040)
+```
+
+Modify the ShinyDriver instantiation in the test script to provide the host and port in the `url` parameter :
+```{r}
+...
+client <- ShinyDriver$new(test_path("apps/outputs"),
+                            url = "http://localhost:4040"
+                            )
+...
+```
+
+You can now single-step through the test script in a new R session and see it's 
+effect on the app in the first session.
+
 
 ### Screenshots
 


### PR DESCRIPTION
One of my `shinytest` scripts triggered an error in the app that did not occur when the app ran interactively, so I needed to use the debugger on the app as the test script executed.

A few additional lines of code allows running the `shiny` app in one RStudio instance, and the `shinytest` script in another instance by providing an additional (optional) `url` argument.

This PR is independent of #324. and should resolve #85.