### PR TITLE
Implement inform_where()

### DIFF
--- a/R/set-inputs.R
+++ b/R/set-inputs.R
@@ -29,7 +29,7 @@ sd_setInputs <- function(self, private, ..., wait_ = TRUE, values_ = TRUE,
     calls <- sys.calls()
     call_text <- deparse(calls[[length(calls) - 1]])
 
-    inform(paste0(
+    inform_where(paste0(
       "setInputs(", call_text, "): ",
       "Server did not update any output values within ",
       format(timeout_/1000, digits = 2), " seconds. ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -237,3 +237,10 @@ httr_get <- function(url) {
   cat("----------------------------------------\n")
   stop("Unable request data from server")
 }
+
+inform_where <- function(message) {
+  bt <- trace_back(bottom = parent.frame())
+  bt_string <- paste0(format(bt), collapse = "\n")
+
+  inform(paste0(message, "\n", bt_string))
+}


### PR DESCRIPTION
Works like inform() but also tells you where the message came from. Fixes #127.

I have zero clues about how to test it, but this gives you an idea of what the output will look like:

```R

f <- function() g()
g <- function() h()
h <- function() inform_where("Bad things happened")

#> Bad things happened
#>     █
#>  1. └─global::f()
#>  2.   └─global::g() ~/Desktop/test.R:2:5
#>  3.     └─global::h() ~/Desktop/test.R:3:5
```