### PR TITLE
`app_path()` should work with trailing `/`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -139,7 +139,8 @@ is_app <- function(path) {
 }
 
 app_path <- function(path, arg = "path") {
-  if (!file.exists(path)) {
+  # must also check for dir (windows trailing '/')
+  if (!(file.exists(path) || dir.exists(path))) {
     stop(paste0("'", path, "' doesn't exist"), call. = FALSE)
   }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -93,3 +93,8 @@ test_that("can find three styles of app", {
   expect_error(app_path(test_path("apps/two-rmd")), "exactly one")
   expect_error(app_path(test_path("apps/two-rmd/doc1.Rmd")), "only one")
 })
+
+
+test_that("app_path works with trailing slash", {
+  expect_error(app_path("../"), NA)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -96,5 +96,5 @@ test_that("can find three styles of app", {
 
 
 test_that("app_path works with trailing slash", {
-  expect_error(app_path("../"), NA)
+  expect_error(app_path("apps/stopApp/"), NA)
 })


### PR DESCRIPTION
Offending line: https://github.com/rstudio/shinytest/commit/bd9646ae6fa770f139add3144391f04fc39177dc#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR128

Causing errors in shiny template tests.

?file.exists
> (However, directory names must not include a trailing backslash or slash on Windows.)