### PR TITLE
Leverage shinyAppDir()'s new exception class for more accurate error messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,8 @@ Suggests:
     globals,
     rmarkdown
 Remotes:
-    rstudio/webdriver
+    rstudio/webdriver,
+    rstudio/shiny
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -136,12 +136,12 @@ is_app <- function(path) {
       # shiny::shinyAppDir() throws an error of this class when the directory
       # doesn't contain an app.R (or server.R) file
       # https://github.com/rstudio/shiny/blob/8aee43c/R/shinyapp.R#L128-L131
-      if (inherits(e, "shiny_app_dir_missing_file")) {
-        return(FALSE)
+      if (!inherits(e, "shiny_app_dir_missing_file")) {
+        # If shiny::shinyAppDir() errors out for other reasons, it's likely
+        # due to sourcing the app file(s), which the user should know about
+        warning(conditionMessage(e))
       }
-      # If shiny::shinyAppDir() errors out for other reasons, it's likely
-      # due to sourcing the app file(s), which the user should fix
-      stop(conditionMessage(e))
+      FALSE
     }
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -133,7 +133,15 @@ is_app <- function(path) {
       TRUE
     },
     error = function(e) {
-      FALSE
+      # shiny::shinyAppDir() throws an error of this class when the directory
+      # doesn't contain an app.R (or server.R) file
+      # https://github.com/rstudio/shiny/blob/8aee43c/R/shinyapp.R#L128-L131
+      if (inherits(e, "shiny_app_dir_missing_file")) {
+        return(FALSE)
+      }
+      # If shiny::shinyAppDir() errors out for other reasons, it's likely
+      # due to sourcing the app file(s), which the user should fix
+      stop(conditionMessage(e))
     }
   )
 }

--- a/tests/testthat/apps/user-error/app.R
+++ b/tests/testthat/apps/user-error/app.R
@@ -1,0 +1,1 @@
+stop("boom")

--- a/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/001.json
+++ b/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/001.json
@@ -7,20 +7,17 @@
     "dynamic_value": " int 10",
     "input_type_text": "slider",
     "ui": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"dynamic\">Dynamic<\/label>\n  <input class=\"js-range-slider\" id=\"dynamic\" data-min=\"1\" data-max=\"20\" data-from=\"10\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.5\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"dynamic-label\" for=\"dynamic\">Dynamic<\/label>\n  <input class=\"js-range-slider\" id=\"dynamic\" data-skin=\"shiny\" data-min=\"1\" data-max=\"20\" data-from=\"10\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.5\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>",
       "deps": [
         {
-          "name": "ionrangeslider",
-          "version": "2.1.6",
+          "name": "ionrangeslider-javascript",
+          "version": "2.3.1",
           "src": {
             "href": "shared/ionrangeslider"
           },
           "meta": null,
           "script": "js/ion.rangeSlider.min.js",
-          "stylesheet": [
-            "css/ion.rangeSlider.css",
-            "css/ion.rangeSlider.skinShiny.css"
-          ],
+          "stylesheet": null,
           "head": null,
           "attachment": null,
           "package": null,
@@ -35,6 +32,20 @@
           "meta": null,
           "script": "strftime-min.js",
           "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": true
+        },
+        {
+          "name": "ionrangeslider-css",
+          "version": "2.3.1",
+          "src": {
+            "href": "shared/ionrangeslider"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "css/ion.rangeSlider.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/002.json
+++ b/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/002.json
@@ -7,20 +7,17 @@
     "dynamic_value": " int 17",
     "input_type_text": "slider",
     "ui": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"dynamic\">Dynamic<\/label>\n  <input class=\"js-range-slider\" id=\"dynamic\" data-min=\"1\" data-max=\"20\" data-from=\"10\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.5\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"dynamic-label\" for=\"dynamic\">Dynamic<\/label>\n  <input class=\"js-range-slider\" id=\"dynamic\" data-skin=\"shiny\" data-min=\"1\" data-max=\"20\" data-from=\"10\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.5\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>",
       "deps": [
         {
-          "name": "ionrangeslider",
-          "version": "2.1.6",
+          "name": "ionrangeslider-javascript",
+          "version": "2.3.1",
           "src": {
             "href": "shared/ionrangeslider"
           },
           "meta": null,
           "script": "js/ion.rangeSlider.min.js",
-          "stylesheet": [
-            "css/ion.rangeSlider.css",
-            "css/ion.rangeSlider.skinShiny.css"
-          ],
+          "stylesheet": null,
           "head": null,
           "attachment": null,
           "package": null,
@@ -35,6 +32,20 @@
           "meta": null,
           "script": "strftime-min.js",
           "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": true
+        },
+        {
+          "name": "ionrangeslider-css",
+          "version": "2.3.1",
+          "src": {
+            "href": "shared/ionrangeslider"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "css/ion.rangeSlider.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/005.json
+++ b/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/005.json
@@ -7,18 +7,21 @@
     "dynamic_value": " chr \"option2\"",
     "input_type_text": "selectInput",
     "ui": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"dynamic\">Dynamic<\/label>\n  <div>\n    <select id=\"dynamic\"><option value=\"option1\">Option 1<\/option>\n<option value=\"option2\" selected>Option 2<\/option><\/select>\n    <script type=\"application/json\" data-for=\"dynamic\" data-nonempty=\"\">{}<\/script>\n  <\/div>\n<\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"dynamic-label\" for=\"dynamic\">Dynamic<\/label>\n  <div>\n    <select id=\"dynamic\"><option value=\"option1\">Option 1<\/option>\n<option value=\"option2\" selected>Option 2<\/option><\/select>\n    <script type=\"application/json\" data-for=\"dynamic\" data-nonempty=\"\">{\"plugins\":[\"selectize-plugin-a11y\"]}<\/script>\n  <\/div>\n<\/div>",
       "deps": [
         {
           "name": "selectize",
-          "version": "0.11.2",
+          "version": "0.12.4",
           "src": {
             "href": "shared/selectize"
           },
           "meta": null,
-          "script": null,
+          "script": [
+            "js/selectize.min.js",
+            "accessibility/js/selectize-plugin-a11y.min.js"
+          ],
           "stylesheet": "css/selectize.bootstrap3.css",
-          "head": "<!--[if lt IE 9]>\n<script src=\"shared/selectize/js/es5-shim.min.js\"><\/script>\n<![endif]-->\n<script src=\"shared/selectize/js/selectize.min.js\"><\/script>",
+          "head": null,
           "attachment": null,
           "package": null,
           "all_files": true

--- a/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/006.json
+++ b/tests/testthat/recorded_tests/041-dynamic-ui/tests/shinytest/mytest-expected/006.json
@@ -7,18 +7,21 @@
     "dynamic_value": " chr \"option1\"",
     "input_type_text": "selectInput",
     "ui": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"dynamic\">Dynamic<\/label>\n  <div>\n    <select id=\"dynamic\"><option value=\"option1\">Option 1<\/option>\n<option value=\"option2\" selected>Option 2<\/option><\/select>\n    <script type=\"application/json\" data-for=\"dynamic\" data-nonempty=\"\">{}<\/script>\n  <\/div>\n<\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"dynamic-label\" for=\"dynamic\">Dynamic<\/label>\n  <div>\n    <select id=\"dynamic\"><option value=\"option1\">Option 1<\/option>\n<option value=\"option2\" selected>Option 2<\/option><\/select>\n    <script type=\"application/json\" data-for=\"dynamic\" data-nonempty=\"\">{\"plugins\":[\"selectize-plugin-a11y\"]}<\/script>\n  <\/div>\n<\/div>",
       "deps": [
         {
           "name": "selectize",
-          "version": "0.11.2",
+          "version": "0.12.4",
           "src": {
             "href": "shared/selectize"
           },
           "meta": null,
-          "script": null,
+          "script": [
+            "js/selectize.min.js",
+            "accessibility/js/selectize-plugin-a11y.min.js"
+          ],
           "stylesheet": "css/selectize.bootstrap3.css",
-          "head": "<!--[if lt IE 9]>\n<script src=\"shared/selectize/js/es5-shim.min.js\"><\/script>\n<![endif]-->\n<script src=\"shared/selectize/js/selectize.min.js\"><\/script>",
+          "head": null,
           "attachment": null,
           "package": null,
           "all_files": true

--- a/tests/testthat/recorded_tests/app-waitForValue/tests/shinytest/mytest-expected/001.json
+++ b/tests/testthat/recorded_tests/app-waitForValue/tests/shinytest/mytest-expected/001.json
@@ -5,9 +5,10 @@
   },
   "output": {
     "distPlot": {
-      "src": "[image data sha1: 0e9029ef927ecee77e2982a814d555d06ab824c1]",
+      "src": "[image data sha1: 508e0e3c2f8ad5cf7cf584b7879e793d902ec2f0]",
       "width": 962,
       "height": 400,
+      "alt": "Plot object",
       "coordmap": {
         "panels": [
           {
@@ -39,20 +40,17 @@
       }
     },
     "dynamic_output": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"bins\">Number of bins:<\/label>\n  <input class=\"js-range-slider\" id=\"bins\" data-min=\"1\" data-max=\"50\" data-from=\"30\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.8\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>\n<div id=\"distPlot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"><\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"bins-label\" for=\"bins\">Number of bins:<\/label>\n  <input class=\"js-range-slider\" id=\"bins\" data-skin=\"shiny\" data-min=\"1\" data-max=\"50\" data-from=\"30\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.8\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>\n<div id=\"distPlot\" class=\"shiny-plot-output\" style=\"width:100%;height:400px;\"><\/div>",
       "deps": [
         {
-          "name": "ionrangeslider",
-          "version": "2.1.6",
+          "name": "ionrangeslider-javascript",
+          "version": "2.3.1",
           "src": {
             "href": "shared/ionrangeslider"
           },
           "meta": null,
           "script": "js/ion.rangeSlider.min.js",
-          "stylesheet": [
-            "css/ion.rangeSlider.css",
-            "css/ion.rangeSlider.skinShiny.css"
-          ],
+          "stylesheet": null,
           "head": null,
           "attachment": null,
           "package": null,
@@ -67,6 +65,20 @@
           "meta": null,
           "script": "strftime-min.js",
           "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": true
+        },
+        {
+          "name": "ionrangeslider-css",
+          "version": "2.3.1",
+          "src": {
+            "href": "shared/ionrangeslider"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "css/ion.rangeSlider.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/recorded_tests/app-waitForValue/tests/shinytest/mytest-expected/002.json
+++ b/tests/testthat/recorded_tests/app-waitForValue/tests/shinytest/mytest-expected/002.json
@@ -5,9 +5,10 @@
   },
   "output": {
     "distPlot": {
-      "src": "[image data sha1: 30b392316dc202b60767f7f5b9e8751a111dbe26]",
+      "src": "[image data sha1: 3aba9e548ebd29814ae43b782181d24cf19d9c3a]",
       "width": 962,
       "height": 400,
+      "alt": "Plot object",
       "coordmap": {
         "panels": [
           {
@@ -39,20 +40,17 @@
       }
     },
     "dynamic_output": {
-      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" for=\"bins\">Number of bins:<\/label>\n  <input class=\"js-range-slider\" id=\"bins\" data-min=\"1\" data-max=\"50\" data-from=\"30\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.8\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>\n<div id=\"distPlot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"><\/div>",
+      "html": "<div class=\"form-group shiny-input-container\">\n  <label class=\"control-label\" id=\"bins-label\" for=\"bins\">Number of bins:<\/label>\n  <input class=\"js-range-slider\" id=\"bins\" data-skin=\"shiny\" data-min=\"1\" data-max=\"50\" data-from=\"30\" data-step=\"1\" data-grid=\"true\" data-grid-num=\"9.8\" data-grid-snap=\"false\" data-prettify-separator=\",\" data-prettify-enabled=\"true\" data-keyboard=\"true\" data-data-type=\"number\"/>\n<\/div>\n<div id=\"distPlot\" class=\"shiny-plot-output\" style=\"width:100%;height:400px;\"><\/div>",
       "deps": [
         {
-          "name": "ionrangeslider",
-          "version": "2.1.6",
+          "name": "ionrangeslider-javascript",
+          "version": "2.3.1",
           "src": {
             "href": "shared/ionrangeslider"
           },
           "meta": null,
           "script": "js/ion.rangeSlider.min.js",
-          "stylesheet": [
-            "css/ion.rangeSlider.css",
-            "css/ion.rangeSlider.skinShiny.css"
-          ],
+          "stylesheet": null,
           "head": null,
           "attachment": null,
           "package": null,
@@ -67,6 +65,20 @@
           "meta": null,
           "script": "strftime-min.js",
           "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "package": null,
+          "all_files": true
+        },
+        {
+          "name": "ionrangeslider-css",
+          "version": "2.3.1",
+          "src": {
+            "href": "shared/ionrangeslider"
+          },
+          "meta": null,
+          "script": null,
+          "stylesheet": "css/ion.rangeSlider.css",
           "head": null,
           "attachment": null,
           "package": null,

--- a/tests/testthat/recorded_tests/inline-img-src/tests/shinytest/mytest-expected/001.json
+++ b/tests/testthat/recorded_tests/inline-img-src/tests/shinytest/mytest-expected/001.json
@@ -13,6 +13,7 @@
       "src": "[image data sha1: 22c2949ed4c7518fbeafff975d3d5780e1bbf04f]",
       "width": 30,
       "height": 30,
+      "alt": "Plot object",
       "coordmap": {
         "panels": [
           {
@@ -47,6 +48,7 @@
       "src": "[image data sha1: de8245a8a5d95796ade12f6dae6a23b28e11a2a0]",
       "width": 30,
       "height": 30,
+      "alt": "Plot object",
       "coordmap": {
         "panels": [
           {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -92,6 +92,8 @@ test_that("can find three styles of app", {
 
   expect_error(app_path(test_path("apps/two-rmd")), "exactly one")
   expect_error(app_path(test_path("apps/two-rmd/doc1.Rmd")), "only one")
+
+  expect_error(app_path(test_path("apps/user-error")), "boom")
 })
 
 


### PR DESCRIPTION
(Builds on https://github.com/rstudio/shiny/pull/3229)

Due to [recent changes](https://github.com/rstudio/shinytest/commit/bd9646ae6fa770f139add3144391f04fc39177dc), running `testApp()` on a directory with a `app.R`/`server.R` file (which throws an error) now throws with an incorrect, and very confusing, error:

```r
> shinytest::testApp()
Error: `appDir` doesn't contain 'app.R', 'server.R', or exactly one '.Rmd'
```

For example, suppose I have a `./app.R` file that simply contains:

```r
stop("boom")
```

With this fix, you'll now get the same error that you'd get if you were to do `shiny::runApp()`

```r
> shinytest::testApp()
Error in value[[3L]](cond) : boom
```


