### PR TITLE
In `initialize()`, wait for navigation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shinytest
 Title: Test Shiny Apps
-Version: 1.5.0.9000
+Version: 1.5.0.9001
 Authors@R:
     c(person(given = "Winston",
              family = "Chang",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-shinytest 1.5.0.9000
+shinytest 1.5.0.9001
 ===============
 
+* `ShinyDriver$initialize()` now waits for the browser to navigate to the page before it injects the JavaScript testing code. This is needed when using phantomjs 2.5.0-beta. (#388)
 
 shinytest 1.5.0
 ===============

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -45,6 +45,11 @@ sd_initialize <- function(self, private, path, loadTimeout, checkNames,
   self$logEvent("Navigating to Shiny app")
   private$web$go(private$getShinyUrl())
 
+  "!DEBUG wait for navigation to happen"
+  while(private$web$getUrl() == "about:blank") {
+    Sys.sleep(0.1)
+  }
+
   "!DEBUG inject shiny-tracer.js"
   self$logEvent("Injecting shiny-tracer.js")
   js_file <- system.file("js", "shiny-tracer.js", package = "shinytest")

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -47,7 +47,7 @@ sd_initialize <- function(self, private, path, loadTimeout, checkNames,
 
   "!DEBUG wait for navigation to happen"
   nav_stop_time <- as.numeric(Sys.time()) + loadTimeout
-  while(private$web$getUrl() == "about:blank") {
+  while(identical(private$web$getUrl(), "about:blank")) {
     if (as.numeric(Sys.time()) > nav_stop_time) {
       abort(paste0(
         "Failed to navigate to Shiny app in ", loadTimeout, "ms.\n",

--- a/R/initialize.R
+++ b/R/initialize.R
@@ -46,7 +46,15 @@ sd_initialize <- function(self, private, path, loadTimeout, checkNames,
   private$web$go(private$getShinyUrl())
 
   "!DEBUG wait for navigation to happen"
+  nav_stop_time <- as.numeric(Sys.time()) + loadTimeout
   while(private$web$getUrl() == "about:blank") {
+    if (as.numeric(Sys.time()) > nav_stop_time) {
+      abort(paste0(
+        "Failed to navigate to Shiny app in ", loadTimeout, "ms.\n",
+        format(self$getDebugLog())
+      ))
+    }
+
     Sys.sleep(0.1)
   }
 


### PR DESCRIPTION
This fixes a problem with using phantomjs 2.5.0-beta on Windows:

```
Error in session_makeRequest(self, private, endpoint, data, params, headers): Detected a page unload event; asynchronous script execution does not work across page loads.
```

This PR makes `$initialize()` to wait until the browser actually navigates to the page before continuing.