### PR TITLE
improve little bits for in-pkg use

### DIFF
--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -66,7 +66,7 @@ For more information about this script, see the [Test driver script notes](#Test
 
 ## Application objects created by functions
 
-The second way have an application in an R package is by having a function that returns a Shiny application object. In this example, there's a function `helloWorldApp()`, which lives in R/helloworld.R:
+The second way to have an application in an R package is by having a function that returns a Shiny application object. In this example, there's a function `helloWorldApp()`, which lives in R/helloworld.R:
 
 ```
 /
@@ -80,7 +80,12 @@ The second way have an application in an R package is by having a function that 
     ├── testthat
     │   ├── apps/
     │   │   └── helloworld/
-    |   |     └── app.R
+    |   |       ├── app.R
+    │   │       └── tests
+    │   │           └── shinytest
+    │   │               ├── mytest-expected
+    │   │               │   └── 001.json
+    │   │               └── mytest.R
     │   └── test-app-function.R
     └── testthat.R
 ```
@@ -129,7 +134,8 @@ test_that("helloWorldApp() works", {
   # Use compareImages=FALSE because the expected image screenshots were created
   # on a Mac, and they will differ from screenshots taken on the CI platform,
   # which runs on Linux.
-  expect_pass(testApp("apps/helloworld/", compareImages = FALSE))
+  # testthat::test_path() ensures that the path can be found in various contexts
+  expect_pass(testApp(test_path("apps/helloworld/"), compareImages = FALSE))
 })
 ```
 


### PR DESCRIPTION
- some files seemed to missing in tree
- `test_path()` makes interactive use easier
   and brings behavior more in line with testthat workflow