### PR TITLE
Remind users to install the package

### DIFF
--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -181,8 +181,7 @@ If you will be testing the package on multiple different platforms, then when ca
 
 You may have noticed the `expect_pass()` function, which is from the shinytest package (instead of most `expect_` functions, which are from the testthat package).
 
-Also note that the test driver scripts requires your package to be *installed*. [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) and related wrappers which you may be familiar with from interactive use, will `pkgload::load_all()` the source package under development. You can still use `test_local()` to test the package, but you will need to install it first.
-Otherwise, you may create a confusing situation where your shinytest-tests run on a *different* version of your package (whichever was last installed), than the rest of your tests (the current source).
+Also note that the `shinytest` scripts require your package to be *installed*. [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) (and related wrappers) eventually call `pkgload::load_all()` to temporarily source the local R package. You can use `test_local()` to test non-`shinytest` tests, but you will need to install your R package to safely execute your `shinytest` tests. If not installed, it will create a confusing situation where your `shinytest` tests run on a *different* version of your R package (whichever was last installed), than the rest of your tests (the current source).
 
 
 ## Continuous integration

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -181,6 +181,9 @@ If you will be testing the package on multiple different platforms, then when ca
 
 You may have noticed the `expect_pass()` function, which is from the shinytest package (instead of most `expect_` functions, which are from the testthat package).
 
+Also note that the test driver scripts requires your package to be *installed*. [`testthat::test_local()`](https://testthat.r-lib.org/reference/test_package.html) and related wrappers which you may be familiar with from interactive use, will `pkgload::load_all()` the source package under development. You can still use `test_local()` to test the package, but you will need to install it first.
+Otherwise, you may create a confusing situation where your shinytest-tests run on a *different* version of your package (whichever was last installed), than the rest of your tests (the current source).
+
 
 ## Continuous integration
 


### PR DESCRIPTION
related to, though not fixing https://github.com/rstudio/shinytest/issues/397

As suggested by @schloerke in #398:

> I would rather we mention to reinstall where appropriate, rather than using `devtools::load_all()`.
