### PR TITLE
use test_path for app paths

### DIFF
--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -129,7 +129,7 @@ test_that("helloWorldApp() works", {
   # Use compareImages=FALSE because the expected image screenshots were created
   # on a Mac, and they will differ from screenshots taken on the CI platform,
   # which runs on Linux.
-  expect_pass(testApp("apps/helloworld/", compareImages = FALSE))
+  expect_pass(testApp(test_path("apps/helloworld/"), compareImages = FALSE))
 })
 ```
 
@@ -169,7 +169,7 @@ test_that("helloWorldApp() works", {
   # Use compareImages=FALSE because the expected image screenshots were created
   # on a Mac, and they will differ from screenshots taken on the CI platform,
   # which runs on Linux.
-  expect_pass(testApp("apps/helloworld/", compareImages = FALSE))
+  expect_pass(testApp(test_path("apps/helloworld/"), compareImages = FALSE))
 })
 ```
 


### PR DESCRIPTION
should make it easier to use interactively
spun out from other changes in https://github.com/rstudio/shinytest/pull/396, before it gets bogged down there in other changes