### PR TITLE
Support HTTP authentication in URLs

### DIFF
--- a/R/initialize.R
+++ b/R/initialize.R
@@ -201,7 +201,17 @@ sd_startShiny <- function(self, private, path, seed, loadTimeout, shinyOptions, 
 
 sd_getShinyUrl <- function(self, private) {
   paste0(
-    private$shinyUrlProtocol, "://", private$shinyUrlHost,
+    private$shinyUrlProtocol, "://",
+    if (isTRUE(nchar(private$shinyUrlUser) > 0)) {
+      paste0(
+        private$shinyUrlUser,
+        if (isTRUE(nchar(private$shinyUrlPass) > 0)) {
+          paste0(":", private$shinyUrlPass)
+        },
+        "@"
+      )
+    },
+    private$shinyUrlHost,
     if (!is.null(private$shinyUrlPort)) paste0(":", private$shinyUrlPort),
     private$shinyUrlPath
   )
@@ -223,6 +233,8 @@ sd_setShinyUrl <- function(self, private, url) {
   assert_that(is_url_path(res$path))
 
   private$shinyUrlProtocol <- res$protocol
+  private$shinyUrlUser     <- res$user
+  private$shinyUrlPass     <- res$pass
   private$shinyUrlHost     <- res$host
   private$shinyUrlPort     <- res$port
   private$shinyUrlPath     <- res$path

--- a/R/shiny-driver.R
+++ b/R/shiny-driver.R
@@ -465,6 +465,8 @@ ShinyDriver <- R6Class(
     path = NULL,                        # Full path to app (including filename if it's a .Rmd)
     shinyUrlProtocol = NULL,            # "http" or "https"
     shinyUrlHost = NULL,                # usually 127.0.0.1
+    shinyUrlUser = NULL,
+    shinyUrlPass = NULL,
     shinyUrlPort = NULL,
     shinyUrlPath = NULL,
     shinyProcess = NULL,                # process object

--- a/R/utils.R
+++ b/R/utils.R
@@ -95,7 +95,7 @@ rel_path <- function(path, base = getwd()) {
 }
 
 parse_url <- function(url) {
-  res <- regexpr("^(?<protocol>https?)://(?<host>[^:/]+)(:(?<port>\\d+))?(?<path>/.*)?$", url, perl = TRUE)
+  res <- regexpr("^(?<protocol>https?)://((?<user>[^:]*)(:(?<pass>.*))?@)?(?<host>[^:/]+)(:(?<port>\\d+))?(?<path>/.*)?$", url, perl = TRUE)
 
   if (res == -1) abort(paste0(url, " is not a valid URL."))
 
@@ -110,6 +110,8 @@ parse_url <- function(url) {
 
   list(
     protocol = get_piece("protocol"),
+    user     = get_piece("user"),
+    pass     = get_piece("pass"),
     host     = get_piece("host"),
     port     = get_piece("port"),
     path     = get_piece("path")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -26,35 +26,73 @@ test_that("rel_path works", {
 test_that("parse_url", {
   expect_identical(
     parse_url("http://a.b.com"),
-    list(protocol = "http", host = "a.b.com", port = "", path = "")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "",
+      path = ""
+    )
   )
   expect_identical(
     parse_url("https://a.b.com/"),
-    list(protocol = "https", host = "a.b.com", port = "", path = "/")
+    list(
+      protocol = "https", user = "", pass = "", host = "a.b.com", port = "",
+      path = "/"
+    )
   )
   expect_identical(
     parse_url("http://a.b.com:1020"),
-    list(protocol = "http", host = "a.b.com", port = "1020", path = "")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "1020",
+      path = ""
+    )
   )
   expect_identical(
     parse_url("http://a.b.com:1020/"),
-    list(protocol = "http", host = "a.b.com", port = "1020", path = "/")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "1020",
+      path = "/"
+    )
   )
   expect_identical(
     parse_url("http://a.b.com:1020/abc"),
-    list(protocol = "http", host = "a.b.com", port = "1020", path = "/abc")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "1020",
+      path = "/abc"
+    )
   )
   expect_identical(
     parse_url("http://a.b.com:1020/abc/"),
-    list(protocol = "http", host = "a.b.com", port = "1020", path = "/abc/")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "1020",
+      path = "/abc/"
+    )
   )
   expect_identical(
     parse_url("http://a.b.com/abc/"),
-    list(protocol = "http", host = "a.b.com", port = "", path = "/abc/")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "",
+      path = "/abc/"
+    )
   )
   expect_identical(
     parse_url("http://a.b.com/abc/"),
-    list(protocol = "http", host = "a.b.com", port = "", path = "/abc/")
+    list(
+      protocol = "http", user = "", pass = "", host = "a.b.com", port = "",
+      path = "/abc/"
+    )
+  )
+  expect_identical(
+    parse_url("http://user@a.b.com/"),
+    list(
+      protocol = "http", user = "user", pass = "", host = "a.b.com",
+      port = "", path = "/"
+    )
+  )
+  expect_identical(
+    parse_url("http://user:pass@a.b.com/"),
+    list(
+      protocol = "http", user = "user", pass = "pass", host = "a.b.com",
+      port = "", path = "/"
+    )
   )
 
   # Malformed URLs, or non-http/https protocol


### PR DESCRIPTION
@schloerke, https://github.com/rstudio/shinytest/pull/348#issuecomment-1039488132
> Adding support for the user/pass in the url string is very reasonable. A small PR for this logic would be great!

Here you go. I did wonder why `parse_url()` and `sd_getShinyUrl()` don't use `httr::parse_url()` and `httr::build_url()`.