### PR TITLE
Update authors in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,18 +5,18 @@ Authors@R:
     c(person(given = "Winston",
              family = "Chang",
              role = c("aut", "cre"),
-             email = "winston@rstudio.com"),
+             email = "winston@posit.co"),
       person(given = "Gábor",
              family = "Csárdi",
              role = "aut",
-             email = "gabor@rstudio.com"),
+             email = "gabor@posit.co"),
       person(given = "Hadley",
              family = "Wickham",
              role = "aut",
-             email = "hadley@rstudio.com"),
-      person(given = "RStudio",
+             email = "hadley@posit.co"),
+      person(given = "Posit Software, PBC",
              role = c("cph", "fnd")),
-      person(given = "Mango Solutions",
+      person(given = "Ascent Digital Services",
              role = c("cph", "ccp")))
 Description: For automated testing of Shiny applications, using
     a headless browser, driven through 'WebDriver'.


### PR DESCRIPTION
This change is meant to address a message from BDR:

> CRAN packages referring to 'Mango Solutiond'
>
> That is
> 
>         mangoTraining pak processx remotes sasMap shinytest
> 
> 'Mango Solutions' as a software company appears no longer to exist: it
> may mow be part of 'Ascent Digital Science'.  As the manual says [cph]
> refers to
> 
> "(copyright holder, which should be the legal name for an institution or
> corporate body)"
> 
> and needs to be identifiable to people wiching to ask for copyright
> permissions.
> 
> And where they are not the only named copyright holder it needs to be
> made clear which parts are owned by which copyright holder.
> 
> Likely RStudio as copyright holder needs to be updated.